### PR TITLE
Simplified foreign asset creator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,7 +1320,7 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/w3f/ring-proof#9d79ccf8bb72b132262ccc86e4e42e4396d1bfb8"
+source = "git+https://github.com/w3f/ring-proof#b273d33f9981e2bb3375ab45faeb537f7ee35224"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -2601,7 +2601,7 @@ dependencies = [
 [[package]]
 name = "fflonk"
 version = "0.1.0"
-source = "git+https://github.com/w3f/fflonk#1beb0585e1c8488956fac7f05da061f9b41e8948"
+source = "git+https://github.com/w3f/fflonk#1e854f35e9a65d08b11a86291405cdc95baa0a35"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -3130,7 +3130,6 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea1015b5a70616b688dc230cfe50c8af89d972cb132d5a622814d29773b10b9"
 dependencies = [
- "rand 0.8.5",
  "rand_core 0.6.4",
 ]
 
@@ -5291,6 +5290,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-assets"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.3.0#401f8a3e9448db854f5605b679fa085b8f445039"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-authority-discovery"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.3.0#401f8a3e9448db854f5605b679fa085b8f445039"
@@ -5392,6 +5407,26 @@ dependencies = [
  "sp-trie",
  "sp-version",
  "test-relay-sproof-builder",
+]
+
+[[package]]
+name = "pallet-foreign-asset-creator"
+version = "0.1.0"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-assets",
+ "pallet-balances",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "staging-xcm",
 ]
 
 [[package]]
@@ -6658,7 +6693,7 @@ dependencies = [
 [[package]]
 name = "ring"
 version = "0.1.0"
-source = "git+https://github.com/w3f/ring-proof#9d79ccf8bb72b132262ccc86e4e42e4396d1bfb8"
+source = "git+https://github.com/w3f/ring-proof#b273d33f9981e2bb3375ab45faeb537f7ee35224"
 dependencies = [
  "ark-ec",
  "ark-ff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
 	"client/orchestrator-chain-interface",
 	"container-chain-pallets/*",
 	"container-chain-primitives/*",
+	"common-pallets/*",
 	"primitives/*",
 	"test-sproof-builder"
 ]
@@ -32,6 +33,8 @@ frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", branc
 frame-support = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "release-polkadot-v1.3.0", version = "4.0.0-dev", default-features = false }
 frame-system = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "release-polkadot-v1.3.0", version = "4.0.0-dev", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = [ "derive", "max-encoded-len" ] }
+pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.3.0", default-features = false }
+pallet-assets = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.3.0", default-features = false }
 scale-info = { version = "2.1.1", default-features = false }
 sp-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.3.0", default-features = false }
 sp-consensus-aura = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.3.0", default-features = false }

--- a/common-pallets/foreign-asset-creator/Cargo.toml
+++ b/common-pallets/foreign-asset-creator/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "pallet-foreign-asset-creator"
+authors = { workspace = true }
+edition = "2021"
+version = "0.1.0"
+
+[dependencies]
+log = { workspace = true }
+serde = { workspace = true, optional = true }
+
+# Substrate
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+parity-scale-codec = { workspace = true, features = [ "derive" ] }
+scale-info = { workspace = true, features = [ "derive" ] }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
+
+# Benchmarks
+frame-benchmarking = { workspace = true, optional = true }
+
+[dev-dependencies]
+pallet-balances = { workspace = true, features = [ "std" ] }
+pallet-assets = { workspace = true, features = [ "std" ] }
+sp-core = { workspace = true, features = [ "std" ] }
+staging-xcm = { workspace = true, features = [ "std" ] }
+
+[features]
+default = [ "std" ]
+std = [
+	"frame-support/std",
+	"frame-system/std",
+	"parity-scale-codec/std",
+	"scale-info/std",
+	"serde",
+	"sp-io/std",
+	"sp-runtime/std",
+	"sp-std/std"
+]
+
+runtime-benchmarks = [ "frame-benchmarking" ]
+try-runtime = [ "frame-support/try-runtime" ]

--- a/common-pallets/foreign-asset-creator/src/lib.rs
+++ b/common-pallets/foreign-asset-creator/src/lib.rs
@@ -1,0 +1,235 @@
+// Copyright (C) Moondance Labs Ltd.
+// This file is part of Tanssi.
+
+// Tanssi is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Tanssi is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Tanssi.  If not, see <http://www.gnu.org/licenses/>.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use frame_support::pallet;
+pub use pallet::*;
+#[cfg(test)]
+pub mod mock;
+#[cfg(test)]
+pub mod tests;
+
+#[pallet]
+pub mod pallet {
+    use super::*;
+    use frame_support::{
+        pallet_prelude::*,
+        traits::{
+            fungibles::{Create, Destroy},
+            tokens::fungibles,
+        },
+    };
+    use frame_system::pallet_prelude::*;
+
+    #[pallet::pallet]
+    #[pallet::without_storage_info]
+    pub struct Pallet<T>(PhantomData<T>);
+
+    #[pallet::config]
+    pub trait Config: frame_system::Config {
+        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+
+        /// The Foreign Asset Kind.
+        type ForeignAsset: Parameter + Member + Ord + PartialOrd + Default;
+
+        /// Origin that is allowed to create and modify asset information for foreign assets
+        type ForeignAssetCreatorOrigin: EnsureOrigin<Self::RuntimeOrigin>;
+
+        /// Origin that is allowed to create and modify asset information for foreign assets
+        type ForeignAssetModifierOrigin: EnsureOrigin<Self::RuntimeOrigin>;
+
+        /// Origin that is allowed to create and modify asset information for foreign assets
+        type ForeignAssetDestroyerOrigin: EnsureOrigin<Self::RuntimeOrigin>;
+
+        type Fungibles: fungibles::Create<Self::AccountId>
+            + fungibles::Destroy<Self::AccountId>
+            + fungibles::Inspect<Self::AccountId>;
+    }
+
+    pub type AssetBalance<T> = <<T as Config>::Fungibles as fungibles::Inspect<
+        <T as frame_system::Config>::AccountId,
+    >>::Balance;
+    pub type AssetId<T> = <<T as Config>::Fungibles as fungibles::Inspect<
+        <T as frame_system::Config>::AccountId,
+    >>::AssetId;
+
+    /// An error that can occur while executing the mapping pallet's logic.
+    #[pallet::error]
+    pub enum Error<T> {
+        AssetAlreadyExists,
+        AssetDoesNotExist,
+    }
+
+    #[pallet::event]
+    #[pallet::generate_deposit(pub(crate) fn deposit_event)]
+    pub enum Event<T: Config> {
+        /// New asset with the asset manager is registered
+        ForeignAssetCreated {
+            asset_id: AssetId<T>,
+            foreign_asset: T::ForeignAsset,
+        },
+        /// Changed the xcm type mapping for a given asset id
+        ForeignAssetTypeChanged {
+            asset_id: AssetId<T>,
+            new_foreign_asset: T::ForeignAsset,
+        },
+        /// Removed all information related to an assetId
+        ForeignAssetRemoved {
+            asset_id: AssetId<T>,
+            foreign_asset: T::ForeignAsset,
+        },
+        /// Removed all information related to an assetId and destroyed asset
+        ForeignAssetDestroyed {
+            asset_id: AssetId<T>,
+            foreign_asset: T::ForeignAsset,
+        },
+    }
+
+    /// Mapping from an asset id to a Foreign asset type.
+    /// This is mostly used when receiving transaction specifying an asset directly,
+    /// like transferring an asset from this chain to another.
+    #[pallet::storage]
+    #[pallet::getter(fn foreign_asset_for_id)]
+    pub type AssetIdToForeignAsset<T: Config> =
+        StorageMap<_, Blake2_128Concat, AssetId<T>, T::ForeignAsset>;
+
+    /// Reverse mapping of AssetIdToForeignAsset. Mapping from a foreign asset to an asset id.
+    /// This is mostly used when receiving a multilocation XCM message to retrieve
+    /// the corresponding asset in which tokens should me minted.
+    #[pallet::storage]
+    #[pallet::getter(fn asset_id_for_foreign)]
+    pub type ForeignAssetToAssetId<T: Config> =
+        StorageMap<_, Blake2_128Concat, T::ForeignAsset, AssetId<T>>;
+
+    #[pallet::call]
+    impl<T: Config> Pallet<T> {
+        /// Create new asset with the ForeignAssetCreator
+        #[pallet::call_index(0)]
+        #[pallet::weight(0)]
+        pub fn create_foreign_asset(
+            origin: OriginFor<T>,
+            foreign_asset: T::ForeignAsset,
+            asset_id: AssetId<T>,
+            admin: T::AccountId,
+            is_sufficient: bool,
+            min_balance: AssetBalance<T>,
+        ) -> DispatchResult {
+            T::ForeignAssetCreatorOrigin::ensure_origin(origin)?;
+
+            // Ensure such an assetId does not exist
+            ensure!(
+                AssetIdToForeignAsset::<T>::get(&asset_id).is_none(),
+                Error::<T>::AssetAlreadyExists
+            );
+
+            // Important: this creates the asset without taking deposits, so the origin able to do this should be priviledged
+            T::Fungibles::create(asset_id.clone(), admin, is_sufficient, min_balance)?;
+
+            // Insert the association assetId->foreigAsset
+            // Insert the association foreigAsset->assetId
+            AssetIdToForeignAsset::<T>::insert(&asset_id, &foreign_asset);
+            ForeignAssetToAssetId::<T>::insert(&foreign_asset, &asset_id);
+
+            Self::deposit_event(Event::ForeignAssetCreated {
+                asset_id,
+                foreign_asset,
+            });
+            Ok(())
+        }
+
+        /// Change the xcm type mapping for a given assetId
+        /// We also change this if the previous units per second where pointing at the old
+        /// assetType
+        #[pallet::call_index(1)]
+        #[pallet::weight(1)]
+        pub fn change_existing_asset_type(
+            origin: OriginFor<T>,
+            asset_id: AssetId<T>,
+            new_foreign_asset: T::ForeignAsset,
+        ) -> DispatchResult {
+            T::ForeignAssetModifierOrigin::ensure_origin(origin)?;
+
+            let previous_foreign_asset =
+                AssetIdToForeignAsset::<T>::get(&asset_id).ok_or(Error::<T>::AssetDoesNotExist)?;
+
+            // Insert new foreign asset info
+            AssetIdToForeignAsset::<T>::insert(&asset_id, &new_foreign_asset);
+            ForeignAssetToAssetId::<T>::insert(&new_foreign_asset, &asset_id);
+
+            // Remove previous foreign asset info
+            ForeignAssetToAssetId::<T>::remove(&previous_foreign_asset);
+
+            Self::deposit_event(Event::ForeignAssetTypeChanged {
+                asset_id,
+                new_foreign_asset,
+            });
+            Ok(())
+        }
+
+        /// Remove a given assetId -> foreignAsset association
+        #[pallet::call_index(2)]
+        #[pallet::weight(1)]
+        pub fn remove_existing_asset_type(
+            origin: OriginFor<T>,
+            asset_id: AssetId<T>,
+        ) -> DispatchResult {
+            T::ForeignAssetDestroyerOrigin::ensure_origin(origin)?;
+
+            let foreign_asset =
+                AssetIdToForeignAsset::<T>::get(&asset_id).ok_or(Error::<T>::AssetDoesNotExist)?;
+
+            // Remove from AssetIdToForeignAsset
+            AssetIdToForeignAsset::<T>::remove(&asset_id);
+            // Remove from ForeignAssetToAssetId
+            ForeignAssetToAssetId::<T>::remove(&foreign_asset);
+
+            Self::deposit_event(Event::ForeignAssetRemoved {
+                asset_id,
+                foreign_asset,
+            });
+            Ok(())
+        }
+
+        /// Destroy a given foreign assetId
+        /// The weight in this case is the one returned by the trait
+        /// plus the db writes and reads from removing all the associated
+        /// data
+        #[pallet::call_index(3)]
+        #[pallet::weight(1)]
+        pub fn destroy_foreign_asset(origin: OriginFor<T>, asset_id: AssetId<T>) -> DispatchResult {
+            T::ForeignAssetDestroyerOrigin::ensure_origin(origin)?;
+
+            let foreign_asset =
+                AssetIdToForeignAsset::<T>::get(&asset_id).ok_or(Error::<T>::AssetDoesNotExist)?;
+
+            // Important: this starts the destruction process, making sure the assets are non-transferable anymore
+            // make sure the destruction process is completable by other means
+            T::Fungibles::start_destroy(asset_id.clone(), None)?;
+
+            // Remove from AssetIdToForeignAsset
+            AssetIdToForeignAsset::<T>::remove(&asset_id);
+            // Remove from ForeignAssetToAssetId
+            ForeignAssetToAssetId::<T>::remove(&foreign_asset);
+
+            Self::deposit_event(Event::ForeignAssetDestroyed {
+                asset_id,
+                foreign_asset,
+            });
+            Ok(())
+        }
+    }
+}

--- a/common-pallets/foreign-asset-creator/src/mock.rs
+++ b/common-pallets/foreign-asset-creator/src/mock.rs
@@ -1,0 +1,182 @@
+// Copyright (C) Moondance Labs Ltd.
+// This file is part of Tanssi.
+
+// Tanssi is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Tanssi is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Tanssi.  If not, see <http://www.gnu.org/licenses/>.
+
+use super::*;
+use crate as pallet_foreign_asset_creator;
+
+use frame_support::{
+    construct_runtime, parameter_types,
+    traits::{ConstU32, Everything},
+};
+use frame_system::EnsureRoot;
+use sp_core::H256;
+use sp_runtime::traits::{BlakeTwo256, IdentityLookup};
+use sp_runtime::BuildStorage;
+use staging_xcm::latest::prelude::*;
+
+type Block = frame_system::mocking::MockBlock<Test>;
+
+pub type AccountId = u64;
+pub type Balance = u64;
+
+construct_runtime!(
+    pub enum Test
+    {
+        System: frame_system,
+        Balances: pallet_balances,
+        ForeignAssetCreator: pallet_foreign_asset_creator,
+        Assets: pallet_assets,
+    }
+);
+
+parameter_types! {
+    pub const BlockHashCount: u32 = 250;
+}
+impl frame_system::Config for Test {
+    type BaseCallFilter = Everything;
+    type BlockWeights = ();
+    type BlockLength = ();
+    type RuntimeOrigin = RuntimeOrigin;
+    type RuntimeCall = RuntimeCall;
+    type Nonce = u64;
+    type Block = Block;
+    type Hash = H256;
+    type Hashing = BlakeTwo256;
+    type AccountId = AccountId;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type RuntimeEvent = RuntimeEvent;
+    type BlockHashCount = BlockHashCount;
+    type DbWeight = ();
+    type Version = ();
+    type PalletInfo = PalletInfo;
+    type AccountData = pallet_balances::AccountData<u64>;
+    type OnNewAccount = ();
+    type OnKilledAccount = ();
+    type SystemWeightInfo = ();
+    type SS58Prefix = ();
+    type OnSetCode = ();
+    type MaxConsumers = frame_support::traits::ConstU32<16>;
+}
+
+parameter_types! {
+    pub const ExistentialDeposit: u64 = 1;
+}
+
+impl pallet_balances::Config for Test {
+    type Balance = Balance;
+    type DustRemoval = ();
+    type RuntimeEvent = RuntimeEvent;
+    type ExistentialDeposit = ExistentialDeposit;
+    type AccountStore = System;
+    type WeightInfo = ();
+    type MaxLocks = ();
+    type MaxReserves = ();
+    type ReserveIdentifier = [u8; 8];
+    type RuntimeHoldReason = ();
+    type RuntimeFreezeReason = ();
+    type FreezeIdentifier = ();
+    type MaxHolds = ();
+    type MaxFreezes = ();
+}
+
+parameter_types! {
+    pub const AssetDeposit: u64 = 0;
+    pub const ApprovalDeposit: u64 = 0;
+    pub const StringLimit: u32 = 50;
+    pub const MetadataDepositBase: u64 = 0;
+    pub const MetadataDepositPerByte: u64 = 0;
+}
+
+type AssetId = u32;
+
+impl pallet_assets::Config for Test {
+    type RuntimeEvent = RuntimeEvent;
+    type Balance = Balance;
+    type AssetId = AssetId;
+    type AssetIdParameter = parity_scale_codec::Compact<AssetId>;
+    type Currency = Balances;
+    type CreateOrigin = frame_support::traits::NeverEnsureOrigin<AccountId>;
+    type ForceOrigin = EnsureRoot<AccountId>;
+    type AssetDeposit = AssetDeposit;
+    type AssetAccountDeposit = AssetDeposit;
+    type MetadataDepositBase = MetadataDepositBase;
+    type MetadataDepositPerByte = MetadataDepositPerByte;
+    type ApprovalDeposit = ApprovalDeposit;
+    type StringLimit = StringLimit;
+    type Freezer = ();
+    type Extra = ();
+    type CallbackHandle = ();
+    type WeightInfo = ();
+    type RemoveItemsLimit = ConstU32<1000>;
+    pallet_assets::runtime_benchmarks_enabled! {
+        type BenchmarkHelper = ();
+    }
+}
+
+impl Config for Test {
+    type RuntimeEvent = RuntimeEvent;
+    type ForeignAsset = MultiLocation;
+    type ForeignAssetCreatorOrigin = EnsureRoot<AccountId>;
+    type ForeignAssetModifierOrigin = EnsureRoot<AccountId>;
+    type ForeignAssetDestroyerOrigin = EnsureRoot<AccountId>;
+    type Fungibles = Assets;
+}
+
+pub(crate) struct ExtBuilder {
+    // endowed accounts with balances
+    balances: Vec<(AccountId, Balance)>,
+}
+
+impl Default for ExtBuilder {
+    fn default() -> ExtBuilder {
+        ExtBuilder { balances: vec![] }
+    }
+}
+
+impl ExtBuilder {
+    pub(crate) fn build(self) -> sp_io::TestExternalities {
+        let mut t = frame_system::GenesisConfig::<Test>::default()
+            .build_storage()
+            .expect("Frame system builds valid default genesis config");
+
+        pallet_balances::GenesisConfig::<Test> {
+            balances: self.balances,
+        }
+        .assimilate_storage(&mut t)
+        .expect("Pallet balances storage can be assimilated");
+        let mut ext = sp_io::TestExternalities::new(t);
+        ext.execute_with(|| System::set_block_number(1));
+        ext
+    }
+}
+
+pub(crate) fn events() -> Vec<super::Event<Test>> {
+    System::events()
+        .into_iter()
+        .map(|r| r.event)
+        .filter_map(|e| {
+            if let RuntimeEvent::ForeignAssetCreator(inner) = e {
+                Some(inner)
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>()
+}
+
+pub fn expect_events(e: Vec<super::Event<Test>>) {
+    assert_eq!(events(), e);
+}

--- a/common-pallets/foreign-asset-creator/src/tests.rs
+++ b/common-pallets/foreign-asset-creator/src/tests.rs
@@ -1,0 +1,229 @@
+// Copyright (C) Moondance Labs Ltd.
+// This file is part of Tanssi.
+
+// Tanssi is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Tanssi is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Tanssi.  If not, see <http://www.gnu.org/licenses/>.
+use crate::*;
+use mock::*;
+
+use frame_support::{assert_noop, assert_ok};
+use staging_xcm::latest::prelude::*;
+
+#[test]
+fn creating_foreign_works() {
+    ExtBuilder::default().build().execute_with(|| {
+        assert_ok!(ForeignAssetCreator::create_foreign_asset(
+            RuntimeOrigin::root(),
+            MultiLocation::parent(),
+            1u32.into(),
+            1u32.into(),
+            true,
+            1u64,
+        ));
+
+        assert_eq!(
+            ForeignAssetCreator::foreign_asset_for_id(1).unwrap(),
+            MultiLocation::parent()
+        );
+        assert_eq!(
+            ForeignAssetCreator::asset_id_for_foreign(MultiLocation::parent()).unwrap(),
+            1
+        );
+        expect_events(vec![crate::Event::ForeignAssetCreated {
+            asset_id: 1,
+            foreign_asset: MultiLocation::parent(),
+        }])
+    });
+}
+
+#[test]
+fn test_asset_exists_error() {
+    ExtBuilder::default().build().execute_with(|| {
+        assert_ok!(ForeignAssetCreator::create_foreign_asset(
+            RuntimeOrigin::root(),
+            MultiLocation::parent(),
+            1u32.into(),
+            1u32.into(),
+            true,
+            1u64,
+        ));
+        assert_eq!(
+            ForeignAssetCreator::foreign_asset_for_id(1).unwrap(),
+            MultiLocation::parent()
+        );
+        assert_noop!(
+            ForeignAssetCreator::create_foreign_asset(
+                RuntimeOrigin::root(),
+                MultiLocation::parent(),
+                1u32.into(),
+                1u32.into(),
+                true,
+                1u64,
+            ),
+            Error::<Test>::AssetAlreadyExists
+        );
+    });
+}
+
+#[test]
+fn test_regular_user_cannot_call_extrinsics() {
+    ExtBuilder::default().build().execute_with(|| {
+        assert_noop!(
+            ForeignAssetCreator::create_foreign_asset(
+                RuntimeOrigin::signed(1),
+                MultiLocation::parent(),
+                1u32.into(),
+                1u32.into(),
+                true,
+                1u64,
+            ),
+            sp_runtime::DispatchError::BadOrigin
+        );
+
+        assert_noop!(
+            ForeignAssetCreator::change_existing_asset_type(
+                RuntimeOrigin::signed(1),
+                1,
+                MultiLocation::parent()
+            ),
+            sp_runtime::DispatchError::BadOrigin
+        );
+    });
+}
+
+#[test]
+fn test_root_can_change_foreign_asset_for_asset_id() {
+    ExtBuilder::default().build().execute_with(|| {
+        assert_ok!(ForeignAssetCreator::create_foreign_asset(
+            RuntimeOrigin::root(),
+			MultiLocation::parent(),
+			1u32.into(),
+			1u32.into(),
+			true,
+			1u64,
+		));
+
+        assert_ok!(ForeignAssetCreator::change_existing_asset_type(
+            RuntimeOrigin::root(),
+            1,
+            MultiLocation::here()
+        ));
+
+
+        // New associations are stablished
+        assert_eq!(
+            ForeignAssetCreator::foreign_asset_for_id(1).unwrap(),
+            MultiLocation::here()
+        );
+        assert_eq!(
+            ForeignAssetCreator::asset_id_for_foreign(MultiLocation::here()).unwrap(),
+            1
+        );
+
+        // Old ones are deleted
+        assert!(ForeignAssetCreator::asset_id_for_foreign(MultiLocation::parent()).is_none());
+
+        expect_events(vec![
+            crate::Event::ForeignAssetCreated {
+                asset_id: 1,
+                foreign_asset: MultiLocation::parent()
+            },
+            crate::Event::ForeignAssetTypeChanged {
+                asset_id: 1,
+                new_foreign_asset: MultiLocation::here(),
+            },
+        ])
+    });
+}
+
+#[test]
+fn test_asset_id_non_existent_error() {
+    ExtBuilder::default().build().execute_with(|| {
+        assert_noop!(
+            ForeignAssetCreator::change_existing_asset_type(
+                RuntimeOrigin::root(),
+                1,
+                MultiLocation::parent()
+            ),
+            Error::<Test>::AssetDoesNotExist
+        );
+    });
+}
+
+#[test]
+fn test_root_can_remove_asset_association() {
+    ExtBuilder::default().build().execute_with(|| {
+        assert_ok!(ForeignAssetCreator::create_foreign_asset(
+            RuntimeOrigin::root(),
+			MultiLocation::parent(),
+			1u32.into(),
+			1u32.into(),
+			true,
+			1u64,
+		));
+
+        assert_ok!(ForeignAssetCreator::remove_existing_asset_type(
+            RuntimeOrigin::root(),
+            1
+        ));
+
+        // Mappings are deleted
+        assert!(ForeignAssetCreator::foreign_asset_for_id(1).is_none());
+        assert!(ForeignAssetCreator::asset_id_for_foreign(MultiLocation::parent()).is_none());
+
+        expect_events(vec![
+            crate::Event::ForeignAssetCreated {
+                asset_id: 1,
+                foreign_asset: MultiLocation::parent(),
+            },
+            crate::Event::ForeignAssetRemoved {
+                asset_id: 1,
+                foreign_asset: MultiLocation::parent(),
+            },
+        ])
+    });
+}
+
+#[test]
+fn test_destroy_foreign_asset_also_removes_everything() {
+    ExtBuilder::default().build().execute_with(|| {
+        assert_ok!(ForeignAssetCreator::create_foreign_asset(
+            RuntimeOrigin::root(),
+			MultiLocation::parent(),
+			1u32.into(),
+			1u32.into(),
+			true,
+			1u64,
+		));
+
+        assert_ok!(ForeignAssetCreator::destroy_foreign_asset(
+            RuntimeOrigin::root(),
+            1
+        ));
+
+        // Mappings are deleted
+        assert!(ForeignAssetCreator::asset_id_for_foreign(MultiLocation::parent()).is_none());
+        assert!(ForeignAssetCreator::foreign_asset_for_id(1).is_none());
+
+        expect_events(vec![
+            crate::Event::ForeignAssetCreated {
+                asset_id: 1,
+                foreign_asset: MultiLocation::parent()
+            },
+            crate::Event::ForeignAssetDestroyed {
+                asset_id: 1,
+                foreign_asset: MultiLocation::parent()
+            },
+        ])
+    });
+}

--- a/common-pallets/foreign-asset-creator/src/tests.rs
+++ b/common-pallets/foreign-asset-creator/src/tests.rs
@@ -106,19 +106,18 @@ fn test_root_can_change_foreign_asset_for_asset_id() {
     ExtBuilder::default().build().execute_with(|| {
         assert_ok!(ForeignAssetCreator::create_foreign_asset(
             RuntimeOrigin::root(),
-			MultiLocation::parent(),
-			1u32.into(),
-			1u32.into(),
-			true,
-			1u64,
-		));
+            MultiLocation::parent(),
+            1u32.into(),
+            1u32.into(),
+            true,
+            1u64,
+        ));
 
         assert_ok!(ForeignAssetCreator::change_existing_asset_type(
             RuntimeOrigin::root(),
             1,
             MultiLocation::here()
         ));
-
 
         // New associations are stablished
         assert_eq!(
@@ -136,7 +135,7 @@ fn test_root_can_change_foreign_asset_for_asset_id() {
         expect_events(vec![
             crate::Event::ForeignAssetCreated {
                 asset_id: 1,
-                foreign_asset: MultiLocation::parent()
+                foreign_asset: MultiLocation::parent(),
             },
             crate::Event::ForeignAssetTypeChanged {
                 asset_id: 1,
@@ -165,12 +164,12 @@ fn test_root_can_remove_asset_association() {
     ExtBuilder::default().build().execute_with(|| {
         assert_ok!(ForeignAssetCreator::create_foreign_asset(
             RuntimeOrigin::root(),
-			MultiLocation::parent(),
-			1u32.into(),
-			1u32.into(),
-			true,
-			1u64,
-		));
+            MultiLocation::parent(),
+            1u32.into(),
+            1u32.into(),
+            true,
+            1u64,
+        ));
 
         assert_ok!(ForeignAssetCreator::remove_existing_asset_type(
             RuntimeOrigin::root(),
@@ -199,12 +198,12 @@ fn test_destroy_foreign_asset_also_removes_everything() {
     ExtBuilder::default().build().execute_with(|| {
         assert_ok!(ForeignAssetCreator::create_foreign_asset(
             RuntimeOrigin::root(),
-			MultiLocation::parent(),
-			1u32.into(),
-			1u32.into(),
-			true,
-			1u64,
-		));
+            MultiLocation::parent(),
+            1u32.into(),
+            1u32.into(),
+            true,
+            1u64,
+        ));
 
         assert_ok!(ForeignAssetCreator::destroy_foreign_asset(
             RuntimeOrigin::root(),
@@ -218,11 +217,11 @@ fn test_destroy_foreign_asset_also_removes_everything() {
         expect_events(vec![
             crate::Event::ForeignAssetCreated {
                 asset_id: 1,
-                foreign_asset: MultiLocation::parent()
+                foreign_asset: MultiLocation::parent(),
             },
             crate::Event::ForeignAssetDestroyed {
                 asset_id: 1,
-                foreign_asset: MultiLocation::parent()
+                foreign_asset: MultiLocation::parent(),
             },
         ])
     });


### PR DESCRIPTION
This PR proposes a pallet that is similar to the asset-manager from moonbeam but it is a simplified version of it. In this case, the foreign-asset-creator-pallet is only responsible for creating and maintaining an `assetId`<->`ForeignAsset` mapping to ease the following situations:

- knowing which `assetId` to touch whenever we receive an XCM `MultiAsset`
- knowing which `MultiAsset` to send when we are told to send a specific `assetId` to another chain

Important changes:

- **We allow the creator to decide an `assetId` instead of deriving it ourselves through some other mechanism.** The main reason for having a custom derivation for the `assetId` was that one could find a collision with a smart contract on the precompile address, but I believe this case is very ethereum specific and could be addressed in different manners (for instance, by using a smaller `assetId` type)

- No units per second, this if needed should be done in a different pallet

- No local asset creation