### PR TITLE
pass benchmark helper to container-chain-authorities-noting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5041,6 +5041,7 @@ version = "0.9.0"
 source = "git+https://github.com/Moonsong-Labs/moonkit?branch=main#97011f3e1135877c53f4f7fa689efc59126e851b"
 dependencies = [
  "async-trait",
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec",

--- a/container-chain-pallets/authorities-noting/Cargo.toml
+++ b/container-chain-pallets/authorities-noting/Cargo.toml
@@ -73,5 +73,6 @@ runtime-benchmarks = [
 	"cumulus-pallet-parachain-system/runtime-benchmarks",
 	"frame-benchmarking",
 	"hex",
+	"nimbus-primitives/runtime-benchmarks"
 ]
 try-runtime = [ "frame-support/try-runtime" ]

--- a/container-chain-pallets/authorities-noting/src/benchmarks.rs
+++ b/container-chain-pallets/authorities-noting/src/benchmarks.rs
@@ -106,16 +106,15 @@ benchmarks! {
     );
 }
 
-
 /// Benchmark Helper
 pub trait BenchmarkHelper<AuthorityId> {
-	/// Returns the authorities on empty
-	fn authorities_on_empty() -> Vec<AuthorityId>;
+    /// Returns the authorities on empty
+    fn authorities_on_empty() -> Vec<AuthorityId>;
 }
 
 impl<AuthorityId> BenchmarkHelper<AuthorityId> for () {
     fn authorities_on_empty() -> Vec<AuthorityId> {
-        return vec![]
+        return vec![];
     }
 }
 
@@ -125,6 +124,6 @@ use nimbus_primitives::NimbusId;
 use sp_core::ByteArray;
 impl<AuthorityId: From<NimbusId>> BenchmarkHelper<AuthorityId> for NimbusIdBenchmarkHelper {
     fn authorities_on_empty() -> Vec<AuthorityId> {
-        return vec![NimbusId::from_slice(&[1; 32]).unwrap().into()]
+        return vec![NimbusId::from_slice(&[1; 32]).unwrap().into()];
     }
 }

--- a/container-chain-pallets/authorities-noting/src/benchmarks.rs
+++ b/container-chain-pallets/authorities-noting/src/benchmarks.rs
@@ -114,7 +114,7 @@ pub trait BenchmarkHelper<AuthorityId> {
 
 impl<AuthorityId> BenchmarkHelper<AuthorityId> for () {
     fn authorities_on_empty() -> Vec<AuthorityId> {
-        return vec![];
+        vec![]
     }
 }
 
@@ -124,6 +124,6 @@ use nimbus_primitives::NimbusId;
 use sp_core::ByteArray;
 impl<AuthorityId: From<NimbusId>> BenchmarkHelper<AuthorityId> for NimbusIdBenchmarkHelper {
     fn authorities_on_empty() -> Vec<AuthorityId> {
-        return vec![NimbusId::from_slice(&[1; 32]).unwrap().into()];
+        vec![NimbusId::from_slice(&[1; 32]).unwrap().into()]
     }
 }

--- a/container-chain-pallets/authorities-noting/src/benchmarks.rs
+++ b/container-chain-pallets/authorities-noting/src/benchmarks.rs
@@ -105,3 +105,26 @@ benchmarks! {
         crate::mock::Test
     );
 }
+
+
+/// Benchmark Helper
+pub trait BenchmarkHelper<AuthorityId> {
+	/// Returns the authorities on empty
+	fn authorities_on_empty() -> Vec<AuthorityId>;
+}
+
+impl<AuthorityId> BenchmarkHelper<AuthorityId> for () {
+    fn authorities_on_empty() -> Vec<AuthorityId> {
+        return vec![]
+    }
+}
+
+pub struct NimbusIdBenchmarkHelper;
+
+use nimbus_primitives::NimbusId;
+use sp_core::ByteArray;
+impl<AuthorityId: From<NimbusId>> BenchmarkHelper<AuthorityId> for NimbusIdBenchmarkHelper {
+    fn authorities_on_empty() -> Vec<AuthorityId> {
+        return vec![NimbusId::from_slice(&[1; 32]).unwrap().into()]
+    }
+}

--- a/container-chain-pallets/authorities-noting/src/lib.rs
+++ b/container-chain-pallets/authorities-noting/src/lib.rs
@@ -36,7 +36,7 @@ mod tests;
 pub mod weights;
 
 #[cfg(any(test, feature = "runtime-benchmarks"))]
-mod benchmarks;
+pub mod benchmarks;
 #[cfg(feature = "runtime-benchmarks")]
 mod mock_proof;
 #[cfg(feature = "runtime-benchmarks")]

--- a/container-chain-pallets/authorities-noting/src/lib.rs
+++ b/container-chain-pallets/authorities-noting/src/lib.rs
@@ -39,6 +39,8 @@ pub mod weights;
 mod benchmarks;
 #[cfg(feature = "runtime-benchmarks")]
 mod mock_proof;
+#[cfg(feature = "runtime-benchmarks")]
+use crate::benchmarks::BenchmarkHelper;
 
 pub use pallet::*;
 
@@ -407,18 +409,4 @@ impl<T: Config> nimbus_primitives::CanAuthor<T::AuthorityId> for CanAuthor<T> {
         }
         authorities
 	}
-}
-
-/// Benchmark Helper
-#[cfg(feature = "runtime-benchmarks")]
-pub trait BenchmarkHelper<AuthorityId> {
-	/// Returns the authorities on empty
-	fn authorities_on_empty() -> Vec<AuthorityId>;
-}
-
-#[cfg(feature = "runtime-benchmarks")]
-impl<AuthorityId> BenchmarkHelper<AuthorityId> for () {
-    fn authorities_on_empty() -> Vec<AuthorityId> {
-        return vec![]
-    }
 }

--- a/container-chain-pallets/authorities-noting/src/lib.rs
+++ b/container-chain-pallets/authorities-noting/src/lib.rs
@@ -85,7 +85,7 @@ pub mod pallet {
         type AuthorityId: sp_std::fmt::Debug + PartialEq + Clone + FullCodec + TypeInfo;
 
         #[cfg(feature = "runtime-benchmarks")]
-		type BenchmarkHelper: BenchmarkHelper<Self::AuthorityId>;
+        type BenchmarkHelper: BenchmarkHelper<Self::AuthorityId>;
         /// Weight information for extrinsics in this pallet.
         type WeightInfo: WeightInfo;
     }
@@ -399,8 +399,8 @@ impl<T: Config> nimbus_primitives::CanAuthor<T::AuthorityId> for CanAuthor<T> {
     }
 
     #[cfg(feature = "runtime-benchmarks")]
-	fn get_authors(_slot: &u32) -> Vec<T::AuthorityId> {
-		let mut authorities = Pallet::<T>::authorities();
+    fn get_authors(_slot: &u32) -> Vec<T::AuthorityId> {
+        let mut authorities = Pallet::<T>::authorities();
         // If it is empty, we just set some authoritise that are pased by the helper
         // this does not affect anything related to benchmarked values
         if authorities.is_empty() {
@@ -408,5 +408,5 @@ impl<T: Config> nimbus_primitives::CanAuthor<T::AuthorityId> for CanAuthor<T> {
             Authorities::<T>::put(authorities.clone());
         }
         authorities
-	}
+    }
 }

--- a/container-chain-pallets/authorities-noting/src/mock.rs
+++ b/container-chain-pallets/authorities-noting/src/mock.rs
@@ -109,6 +109,8 @@ impl Config for Test {
     type RelayChainStateProvider = MockRelayStateProvider;
     type AuthorityId = AccountId;
     type WeightInfo = ();
+    #[cfg(feature = "runtime-benchmarks")]
+    type BenchmarkHelper = ();
 }
 
 struct BlockTest {


### PR DESCRIPTION
There are certain conditions in which we need to get authors (e.g., for container-chains) but we dont run the inherent (e.g. for benchmarks like pallet-author-inherent). In this case for the benchmark to be correctly set we would need to fetch some authorities somehow.

This PR defines a benchmark helper that can be set so that in case of empty, the author-check does not fail