### PR TITLE
Remove DispatchClass from XcmExecutorUtils pallet calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5219,7 +5219,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 8.0.0",
  "staging-xcm",
 ]
 

--- a/pallets/xcm-executor-utils/src/lib.rs
+++ b/pallets/xcm-executor-utils/src/lib.rs
@@ -180,7 +180,7 @@ pub mod pallet {
     #[pallet::call]
     impl<T: Config> Pallet<T> {
         #[pallet::call_index(0)]
-        #[pallet::weight((T::WeightInfo::set_reserve_policy(), DispatchClass::Mandatory))]
+        #[pallet::weight(T::WeightInfo::set_reserve_policy())]
         pub fn set_reserve_policy(
             origin: OriginFor<T>,
             origin_multilocation: MultiLocation,
@@ -198,7 +198,7 @@ pub mod pallet {
         }
 
         #[pallet::call_index(1)]
-        #[pallet::weight((T::WeightInfo::remove_reserve_policy(), DispatchClass::Mandatory))]
+        #[pallet::weight(T::WeightInfo::remove_reserve_policy())]
         pub fn remove_reserve_policy(
             origin: OriginFor<T>,
             origin_multilocation: MultiLocation,
@@ -215,7 +215,7 @@ pub mod pallet {
         }
 
         #[pallet::call_index(2)]
-        #[pallet::weight((T::WeightInfo::set_teleport_policy(), DispatchClass::Mandatory))]
+        #[pallet::weight(T::WeightInfo::set_teleport_policy())]
         pub fn set_teleport_policy(
             origin: OriginFor<T>,
             origin_multilocation: MultiLocation,
@@ -233,7 +233,7 @@ pub mod pallet {
         }
 
         #[pallet::call_index(3)]
-        #[pallet::weight((T::WeightInfo::remove_teleport_policy(), DispatchClass::Mandatory))]
+        #[pallet::weight(T::WeightInfo::remove_teleport_policy())]
         pub fn remove_teleport_policy(
             origin: OriginFor<T>,
             origin_multilocation: MultiLocation,

--- a/pallets/xcm-executor-utils/src/mock.rs
+++ b/pallets/xcm-executor-utils/src/mock.rs
@@ -66,6 +66,7 @@ pub mod mock_never {
         type SS58Prefix = ConstU16<42>;
         type OnSetCode = ();
         type MaxConsumers = frame_support::traits::ConstU32<16>;
+        type RuntimeTask = ();
     }
 
     parameter_types! {
@@ -130,6 +131,7 @@ pub mod mock_all {
         type SS58Prefix = ConstU16<42>;
         type OnSetCode = ();
         type MaxConsumers = frame_support::traits::ConstU32<16>;
+        type RuntimeTask = ();
     }
 
     parameter_types! {
@@ -186,6 +188,7 @@ pub mod mock_all_native {
         type SS58Prefix = ConstU16<42>;
         type OnSetCode = ();
         type MaxConsumers = frame_support::traits::ConstU32<16>;
+        type RuntimeTask = ();
     }
 
     parameter_types! {


### PR DESCRIPTION
I accidentally added `DispatchClass::Mandatory` to all calls of the xcm executor utils pallet weight annotations.