### PR TITLE
Orchestrator Chain RPC Interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1867,6 +1867,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
+ "dp-core",
  "futures",
  "jsonrpsee",
  "parity-scale-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,21 +580,50 @@ dependencies = [
 
 [[package]]
 name = "async-io"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
+dependencies = [
+ "async-lock 2.8.0",
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-lite 1.13.0",
+ "log",
+ "parking",
+ "polling 2.8.0",
+ "rustix 0.37.27",
+ "slab",
+ "socket2 0.4.10",
+ "waker-fn",
+]
+
+[[package]]
+name = "async-io"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f97ab0c5b00a7cdbe5a371b9a782ee7be1316095885c8a4ea1daf490eb0ef65"
 dependencies = [
- "async-lock",
+ "async-lock 3.3.0",
  "cfg-if",
  "concurrent-queue",
  "futures-io",
- "futures-lite",
+ "futures-lite 2.2.0",
  "parking",
- "polling",
+ "polling 3.3.2",
  "rustix 0.38.30",
  "slab",
  "tracing",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
+dependencies = [
+ "event-listener 2.5.3",
 ]
 
 [[package]]
@@ -1839,6 +1868,7 @@ dependencies = [
  "async-trait",
  "cumulus-primitives-core",
  "futures",
+ "jsonrpsee",
  "parity-scale-codec",
  "polkadot-overseer",
  "sc-client-api",
@@ -2344,6 +2374,15 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
@@ -2796,6 +2835,21 @@ name = "futures-io"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-lite"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+dependencies = [
+ "fastrand 1.9.0",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite 0.2.13",
+ "waker-fn",
+]
 
 [[package]]
 name = "futures-lite"
@@ -3299,7 +3353,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6b0422c86d7ce0e97169cc42e04ae643caf278874a7a3c87b8150a220dc7e1e"
 dependencies = [
- "async-io",
+ "async-io 2.3.1",
  "core-foundation",
  "fnv",
  "futures",
@@ -3518,7 +3572,29 @@ dependencies = [
  "jsonrpsee-proc-macros",
  "jsonrpsee-server",
  "jsonrpsee-types",
+ "jsonrpsee-ws-client",
  "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-client-transport"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8b3815d9f5d5de348e5f162b316dc9cdf4548305ebb15b4eb9328e66cf27d7a"
+dependencies = [
+ "futures-util",
+ "http",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "pin-project",
+ "rustls-native-certs",
+ "soketto",
+ "thiserror",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tracing",
+ "webpki-roots 0.25.4",
 ]
 
 [[package]]
@@ -3529,9 +3605,11 @@ checksum = "2b5dde66c53d6dcdc8caea1874a45632ec0fcf5b437789f1e45766a1512ce803"
 dependencies = [
  "anyhow",
  "arrayvec 0.7.4",
+ "async-lock 2.8.0",
  "async-trait",
  "beef",
  "futures-channel",
+ "futures-timer",
  "futures-util",
  "globset",
  "hyper",
@@ -3594,6 +3672,18 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-ws-client"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e1b3975ed5d73f456478681a417128597acd6a2487855fdb7b4a3d4d195bf5e"
+dependencies = [
+ "http",
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
 ]
 
 [[package]]
@@ -4068,7 +4158,7 @@ dependencies = [
  "rw-stream-sink",
  "soketto",
  "url",
- "webpki-roots",
+ "webpki-roots 0.22.6",
 ]
 
 [[package]]
@@ -4207,6 +4297,12 @@ name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
@@ -4996,6 +5092,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "orchestrator-chain-rpc-interface"
+version = "0.1.0"
+dependencies = [
+ "async-io 1.13.0",
+ "async-trait",
+ "dc-orchestrator-chain-interface",
+ "futures",
+ "jsonrpsee",
+ "parity-scale-codec",
+ "polkadot-overseer",
+ "sc-client-api",
+ "sc-rpc-api",
+ "sc-service",
+ "serde",
+ "serde_json",
+ "sp-api",
+ "sp-blockchain",
+ "sp-core",
+ "sp-state-machine",
+ "sp-storage 13.0.0",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "ordered-float"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5746,6 +5869,22 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
  "sp-core",
+]
+
+[[package]]
+name = "polling"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "concurrent-queue",
+ "libc",
+ "log",
+ "pin-project-lite 0.2.13",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6515,6 +6654,20 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.1.4",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -9106,7 +9259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
 dependencies = [
  "cfg-if",
- "fastrand",
+ "fastrand 2.0.1",
  "redox_syscall 0.4.1",
  "rustix 0.38.30",
  "windows-sys 0.52.0",
@@ -9803,6 +9956,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "waker-fn"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
+
+[[package]]
 name = "walkdir"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10196,6 +10355,12 @@ checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "which"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,12 @@
 [workspace]
 members = [
 	"client/orchestrator-chain-interface",
+	"client/orchestrator-chain-rpc-interface",
 	"container-chain-pallets/*",
 	"container-chain-primitives/*",
 	"pallets/*",
 	"primitives/*",
-	"test-sproof-builder"
+	"test-sproof-builder",
 ]
 resolver = "2"
 
@@ -20,21 +21,22 @@ ccp-xcm = { path = "container-chain-primitives/xcm", default-features = false }
 pallet-cc-authorities-noting = { path = "container-chain-pallets/authorities-noting", default-features = false }
 
 dc-orchestrator-chain-interface = { path = "client/orchestrator-chain-interface" }
-test-relay-sproof-builder = { path = "test-sproof-builder", default-features = false }
+dc-orchestrator-chain-rpc-interface = { path = "client/orchestrator-chain-rpc-interface" }
 dp-chain-state-snapshot = { path = "primitives/chain-state-snapshot", default-features = false }
 dp-collator-assignment = { path = "primitives/collator-assignment", default-features = false }
 dp-core = { path = "primitives/core", default-features = false }
 dp-impl-tanssi-pallets-config = { path = "primitives/core", default-features = false }
+test-relay-sproof-builder = { path = "test-sproof-builder", default-features = false }
 
 # Moonkit (wasm)
 nimbus-primitives = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "main", default-features = false }
 pallet-author-inherent = { git = "https://github.com/Moonsong-Labs/moonkit", branch = "main", default-features = false }
 
 # Substrate (wasm)
-pallet-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0", default-features = false }
 frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0", default-features = false }
 frame-support = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "release-polkadot-v1.6.0", version = "4.0.0-dev", default-features = false }
 frame-system = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "release-polkadot-v1.6.0", version = "4.0.0-dev", default-features = false }
+pallet-timestamp = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = [ "derive", "max-encoded-len" ] }
 scale-info = { version = "2.1.1", default-features = false }
 sp-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0", default-features = false }
@@ -45,13 +47,16 @@ sp-io = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "rele
 sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "release-polkadot-v1.6.0", version = "24.0.0", default-features = false }
 sp-state-machine = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0", default-features = false }
 sp-std = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0", default-features = false }
+sp-storage = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0", default-features = false }
 sp-trie = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0", default-features = false }
 sp-version = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0", default-features = false }
 
 # Substrate (client)
 sc-client-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0" }
+sc-rpc-api = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0" }
+sc-service = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0" }
 sp-blockchain = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0" }
-sp-externalities = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0", default-features = false } 	
+sp-externalities = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0", default-features = false }
 substrate-test-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0" }
 substrate-test-runtime-client = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0" }
 
@@ -73,19 +78,23 @@ cumulus-primitives-parachain-inherent = { git = "https://github.com/paritytech/p
 cumulus-relay-chain-interface = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.6.0", default-features = false }
 
 # General (wasm)
+async-io = "1.3"
 hex-literal = { version = "0.3.4" }
+impls = "1.0.3"
 log = { version = "0.4.17", default-features = false }
 serde = { version = "1.0.152", default-features = false }
+serde_json = { version = "1.0.96", default-features = false }
 smallvec = "1.10.0"
-impls = "1.0.3"
 
 # General (client)
 async-trait = "0.1"
 futures = { version = "0.3.1" }
 hex = { version = "0.4.3", default-features = false }
+jsonrpsee = { version = "0.16.2" }
 thiserror = { version = "1.0.40" }
 tokio = { version = "1.32.0", default-features = false }
 tracing = { version = "0.1.37", default-features = false }
+url = "2.2.2"
 
 [profile.production]
 codegen-units = 1
@@ -96,4 +105,3 @@ lto = true
 [profile.release]
 opt-level = 3
 panic = "unwind"
-

--- a/client/orchestrator-chain-interface/Cargo.toml
+++ b/client/orchestrator-chain-interface/Cargo.toml
@@ -4,9 +4,11 @@ authors = { workspace = true }
 edition = "2021"
 license = "GPL-3.0-only"
 version = "0.1.0"
+
 [dependencies]
 async-trait = { workspace = true }
 futures = { workspace = true }
+jsonrpsee = { workspace = true }
 parity-scale-codec = { workspace = true }
 thiserror = { workspace = true }
 

--- a/client/orchestrator-chain-interface/Cargo.toml
+++ b/client/orchestrator-chain-interface/Cargo.toml
@@ -12,6 +12,9 @@ jsonrpsee = { workspace = true }
 parity-scale-codec = { workspace = true }
 thiserror = { workspace = true }
 
+# Dancekit
+dp-core = { workspace = true }
+
 # Substrate
 sc-client-api = { workspace = true }
 sp-api = { workspace = true, features = [ "std" ] }

--- a/client/orchestrator-chain-interface/src/lib.rs
+++ b/client/orchestrator-chain-interface/src/lib.rs
@@ -34,10 +34,25 @@ use {
 pub enum OrchestratorChainError {
     #[error("Blockchain returned an error: {0}")]
     BlockchainError(#[from] sp_blockchain::Error),
+
     #[error("State machine error occured: {0}")]
     StateMachineError(Box<dyn sp_state_machine::Error>),
+
     #[error(transparent)]
     Application(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
+
+    #[error("Unable to communicate with RPC worker: {0}")]
+    WorkerCommunicationError(String),
+
+    #[error("Unable to call RPC method '{0}': {1}")]
+    RpcCallError(String, String),
+
+    #[error("RPC Error: '{0}'")]
+    JsonRpcError(#[from] jsonrpsee::core::Error),
+
+    #[error("Scale codec deserialization error: {0}")]
+    DeserializationError(#[from] parity_scale_codec::Error),
+
     #[error("Unspecified error occured: {0}")]
     GenericError(String),
 }

--- a/client/orchestrator-chain-interface/src/lib.rs
+++ b/client/orchestrator-chain-interface/src/lib.rs
@@ -24,10 +24,10 @@
 //!
 //! prove_read: generates a storage proof of a given set of keys at a given Orchestrator parent
 
-pub use cumulus_primitives_core::relay_chain::Hash as PHash;
+pub use dp_core::{Hash as PHash, Header as PHeader};
 use {
-    polkadot_overseer::Handle, sc_client_api::StorageProof, sp_api::ApiError,
-    sp_state_machine::StorageValue, std::sync::Arc,
+    core::pin::Pin, futures::Stream, polkadot_overseer::Handle, sc_client_api::StorageProof,
+    sp_api::ApiError, sp_state_machine::StorageValue, std::sync::Arc,
 };
 
 #[derive(thiserror::Error, Debug)]
@@ -103,6 +103,21 @@ pub trait OrchestratorChainInterface: Send + Sync {
         orchestrator_parent: PHash,
         relevant_keys: &[Vec<u8>],
     ) -> OrchestratorChainResult<StorageProof>;
+
+    /// Get a stream of import block notifications.
+    async fn import_notification_stream(
+        &self,
+    ) -> OrchestratorChainResult<Pin<Box<dyn Stream<Item = PHeader> + Send>>>;
+
+    /// Get a stream of new best block notifications.
+    async fn new_best_notification_stream(
+        &self,
+    ) -> OrchestratorChainResult<Pin<Box<dyn Stream<Item = PHeader> + Send>>>;
+
+    /// Get a stream of finality notifications.
+    async fn finality_notification_stream(
+        &self,
+    ) -> OrchestratorChainResult<Pin<Box<dyn Stream<Item = PHeader> + Send>>>;
 }
 
 #[async_trait::async_trait]
@@ -130,5 +145,23 @@ where
         (**self)
             .prove_read(orchestrator_parent, relevant_keys)
             .await
+    }
+
+    async fn import_notification_stream(
+        &self,
+    ) -> OrchestratorChainResult<Pin<Box<dyn Stream<Item = PHeader> + Send>>> {
+        (**self).import_notification_stream().await
+    }
+
+    async fn new_best_notification_stream(
+        &self,
+    ) -> OrchestratorChainResult<Pin<Box<dyn Stream<Item = PHeader> + Send>>> {
+        (**self).new_best_notification_stream().await
+    }
+
+    async fn finality_notification_stream(
+        &self,
+    ) -> OrchestratorChainResult<Pin<Box<dyn Stream<Item = PHeader> + Send>>> {
+        (**self).finality_notification_stream().await
     }
 }

--- a/client/orchestrator-chain-rpc-interface/Cargo.toml
+++ b/client/orchestrator-chain-rpc-interface/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "orchestrator-chain-rpc-interface"
+authors = { workspace = true }
+edition = "2021"
+license = "GPL-3.0-only"
+version = "0.1.0"
+
+[dependencies]
+async-io = { workspace = true }
+async-trait = { workspace = true }
+futures = { workspace = true }
+jsonrpsee = { workspace = true, features = [ "ws-client" ] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = [ "sync" ] }
+tracing = { workspace = true }
+url = { workspace = true }
+
+# Dancekit
+dc-orchestrator-chain-interface = { workspace = true }
+
+# Substrate
+parity-scale-codec = { workspace = true }
+sc-client-api = { workspace = true }
+sc-rpc-api = { workspace = true }
+sc-service = { workspace = true }
+sp-api = { workspace = true, features = [ "std" ] }
+sp-blockchain = { workspace = true }
+sp-core = { workspace = true }
+sp-state-machine = { workspace = true, features = [ "std" ] }
+sp-storage = { workspace = true }
+
+# Polkadot
+polkadot-overseer = { workspace = true }

--- a/client/orchestrator-chain-rpc-interface/src/lib.rs
+++ b/client/orchestrator-chain-rpc-interface/src/lib.rs
@@ -1,0 +1,240 @@
+// Copyright (C) Moondance Labs Ltd.
+// This file is part of Tanssi.
+
+// Tanssi is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Tanssi is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Tanssi.  If not, see <http://www.gnu.org/licenses/>.
+
+mod ws_client;
+
+use {
+    async_trait::async_trait,
+    dc_orchestrator_chain_interface::{
+        OrchestratorChainError, OrchestratorChainInterface, OrchestratorChainResult, PHash,
+    },
+    jsonrpsee::{core::params::ArrayParams, rpc_params},
+    sc_client_api::{StorageData, StorageProof},
+    sc_rpc_api::state::ReadProof,
+    sc_service::TaskManager,
+    serde::de::DeserializeOwned,
+    sp_core::{Decode, Encode},
+    sp_state_machine::StorageValue,
+    sp_storage::StorageKey,
+    tokio::sync::{mpsc, oneshot},
+    url::Url,
+    ws_client::{JsonRpcRequest, WsClientRequest},
+};
+
+const LOG_TARGET: &str = "orchestrator-rpc-client";
+
+/// Format url and force addition of a port
+fn url_to_string_with_port(url: Url) -> Option<String> {
+    // This is already validated on CLI side, just defensive here
+    if (url.scheme() != "ws" && url.scheme() != "wss") || url.host_str().is_none() {
+        tracing::warn!(target: LOG_TARGET, ?url, "Non-WebSocket URL or missing host.");
+        return None;
+    }
+
+    // Either we have a user-supplied port or use the default for 'ws' or 'wss' here
+    Some(format!(
+        "{}://{}:{}{}{}",
+        url.scheme(),
+        url.host_str()?,
+        url.port_or_known_default()?,
+        url.path(),
+        url.query()
+            .map(|query| format!("?{}", query))
+            .unwrap_or_default()
+    ))
+}
+
+pub async fn create_client_and_start_worker(
+    urls: Vec<Url>,
+    task_manager: &mut TaskManager,
+    overseer_handle: polkadot_overseer::Handle,
+) -> OrchestratorChainResult<OrchestratorChainRpcClient> {
+    let urls: Vec<_> = urls
+        .into_iter()
+        .filter_map(url_to_string_with_port)
+        .collect();
+    let (worker, request_sender) = ws_client::ReconnectingWsClientWorker::new(urls)
+        .await
+        .map_err(|_| {
+            OrchestratorChainError::GenericError(
+                "Failed to connect to all provided Orchestrator chain RPC endpoints".to_string(),
+            )
+        })?;
+
+    task_manager
+        .spawn_essential_handle()
+        .spawn("orchestrator-rpc-worker", None, worker.run());
+
+    let client = OrchestratorChainRpcClient {
+        request_sender,
+        overseer_handle,
+    };
+
+    Ok(client)
+}
+
+#[derive(Clone)]
+pub struct OrchestratorChainRpcClient {
+    request_sender: mpsc::Sender<WsClientRequest>,
+    overseer_handle: polkadot_overseer::Handle,
+}
+
+impl OrchestratorChainRpcClient {
+    /// Call a call to `state_call` rpc method.
+    pub async fn call_remote_runtime_function<R: Decode>(
+        &self,
+        method_name: &str,
+        hash: PHash,
+        payload: Option<impl Encode>,
+    ) -> OrchestratorChainResult<R> {
+        let payload_bytes =
+            payload.map_or(sp_core::Bytes(Vec::new()), |v| sp_core::Bytes(v.encode()));
+        let params = rpc_params! {
+            method_name,
+            payload_bytes,
+            hash
+        };
+        let res = self
+            .request_tracing::<sp_core::Bytes, _>("state_call", params, |err| {
+                tracing::trace!(
+                    target: LOG_TARGET,
+                    %method_name,
+                    %hash,
+                    error = %err,
+                    "Error during call to 'state_call'.",
+                );
+            })
+            .await?;
+        Decode::decode(&mut &*res.0).map_err(Into::into)
+    }
+
+    async fn request<'a, R>(
+        &self,
+        method: &'a str,
+        params: ArrayParams,
+    ) -> OrchestratorChainResult<R>
+    where
+        R: DeserializeOwned + std::fmt::Debug,
+    {
+        self.request_tracing(
+            method,
+            params,
+            |e| tracing::trace!(target:LOG_TARGET, error = %e, %method, "Unable to complete RPC request"),
+        ).await
+    }
+
+    /// Send a request to the RPC worker and awaits for a response. The worker is responsible
+    /// for retrying requests if connection dies.
+    async fn request_tracing<'a, R, OR>(
+        &self,
+        method: &'a str,
+        params: ArrayParams,
+        trace_error: OR,
+    ) -> OrchestratorChainResult<R>
+    where
+        R: DeserializeOwned + std::fmt::Debug,
+        OR: Fn(&OrchestratorChainError),
+    {
+        let (response_sender, response_receiver) = oneshot::channel();
+
+        let request = WsClientRequest::JsonRpcRequest(JsonRpcRequest {
+            method: method.into(),
+            params,
+            response_sender,
+        });
+        self.request_sender.send(request).await.map_err(|err| {
+            OrchestratorChainError::WorkerCommunicationError(format!(
+                "Unable to send message to RPC worker: {}",
+                err
+            ))
+        })?;
+
+        let response = response_receiver.await.map_err(|err| {
+			OrchestratorChainError::WorkerCommunicationError(format!(
+				"RPC worker channel closed. This can hint and connectivity issues with the supplied RPC endpoints. Message: {}",
+				err
+			))
+		})??;
+
+        serde_json::from_value(response).map_err(|_| {
+            trace_error(&OrchestratorChainError::GenericError(
+                "Unable to deserialize value".to_string(),
+            ));
+            OrchestratorChainError::RpcCallError(
+                method.to_string(),
+                "failed to decode returned value".to_string(),
+            )
+        })
+    }
+
+    /// Retrieve storage item at `storage_key`
+    pub async fn state_get_storage(
+        &self,
+        storage_key: StorageKey,
+        at: Option<PHash>,
+    ) -> OrchestratorChainResult<Option<StorageData>> {
+        let params = rpc_params![storage_key, at];
+        self.request("state_getStorage", params).await
+    }
+
+    /// Get read proof for `storage_keys`
+    pub async fn state_get_read_proof(
+        &self,
+        storage_keys: Vec<StorageKey>,
+        at: Option<PHash>,
+    ) -> OrchestratorChainResult<ReadProof<PHash>> {
+        let params = rpc_params![storage_keys, at];
+        self.request("state_getReadProof", params).await
+    }
+}
+
+#[async_trait]
+#[async_trait]
+impl OrchestratorChainInterface for OrchestratorChainRpcClient {
+    /// Fetch a storage item by key.
+    async fn get_storage_by_key(
+        &self,
+        orchestrator_parent: PHash,
+        key: &[u8],
+    ) -> OrchestratorChainResult<Option<StorageValue>> {
+        let storage_key = StorageKey(key.to_vec());
+        self.state_get_storage(storage_key, Some(orchestrator_parent))
+            .await
+            .map(|storage_data| storage_data.map(|sv| sv.0))
+    }
+
+    /// Get a handle to the overseer.
+    fn overseer_handle(&self) -> OrchestratorChainResult<polkadot_overseer::Handle> {
+        Ok(self.overseer_handle.clone())
+    }
+
+    /// Generate a storage read proof.
+    async fn prove_read(
+        &self,
+        orchestrator_parent: PHash,
+        relevant_keys: &[Vec<u8>],
+    ) -> OrchestratorChainResult<StorageProof> {
+        let mut cloned = Vec::new();
+        cloned.extend_from_slice(&relevant_keys);
+        let storage_keys: Vec<StorageKey> = cloned.into_iter().map(|key| StorageKey(key)).collect();
+
+        self.state_get_read_proof(storage_keys, Some(orchestrator_parent))
+            .await
+            .map(|read_proof| {
+                StorageProof::new(read_proof.proof.into_iter().map(|bytes| bytes.to_vec()))
+            })
+    }
+}

--- a/client/orchestrator-chain-rpc-interface/src/lib.rs
+++ b/client/orchestrator-chain-rpc-interface/src/lib.rs
@@ -18,9 +18,11 @@ mod ws_client;
 
 use {
     async_trait::async_trait,
+    core::pin::Pin,
     dc_orchestrator_chain_interface::{
-        OrchestratorChainError, OrchestratorChainInterface, OrchestratorChainResult, PHash,
+        OrchestratorChainError, OrchestratorChainInterface, OrchestratorChainResult, PHash, PHeader,
     },
+    futures::Stream,
     jsonrpsee::{core::params::ArrayParams, rpc_params},
     sc_client_api::{StorageData, StorageProof},
     sc_rpc_api::state::ReadProof,
@@ -202,7 +204,6 @@ impl OrchestratorChainRpcClient {
 }
 
 #[async_trait]
-#[async_trait]
 impl OrchestratorChainInterface for OrchestratorChainRpcClient {
     /// Fetch a storage item by key.
     async fn get_storage_by_key(
@@ -236,5 +237,26 @@ impl OrchestratorChainInterface for OrchestratorChainRpcClient {
             .map(|read_proof| {
                 StorageProof::new(read_proof.proof.into_iter().map(|bytes| bytes.to_vec()))
             })
+    }
+
+    /// Get a stream of import block notifications.
+    async fn import_notification_stream(
+        &self,
+    ) -> OrchestratorChainResult<Pin<Box<dyn Stream<Item = PHeader> + Send>>> {
+        todo!()
+    }
+
+    /// Get a stream of new best block notifications.
+    async fn new_best_notification_stream(
+        &self,
+    ) -> OrchestratorChainResult<Pin<Box<dyn Stream<Item = PHeader> + Send>>> {
+        todo!()
+    }
+
+    /// Get a stream of finality notifications.
+    async fn finality_notification_stream(
+        &self,
+    ) -> OrchestratorChainResult<Pin<Box<dyn Stream<Item = PHeader> + Send>>> {
+        todo!()
     }
 }

--- a/client/orchestrator-chain-rpc-interface/src/ws_client.rs
+++ b/client/orchestrator-chain-rpc-interface/src/ws_client.rs
@@ -1,0 +1,251 @@
+// Copyright (C) Moondance Labs Ltd.
+// This file is part of Tanssi.
+
+// Tanssi is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Tanssi is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Tanssi.  If not, see <http://www.gnu.org/licenses/>.
+
+use {
+    futures::{
+        future::BoxFuture,
+        stream::{FuturesUnordered, StreamExt},
+        FutureExt,
+    },
+    jsonrpsee::{
+        core::{
+            client::{Client as JsonRpcClient, ClientT as _},
+            params::ArrayParams,
+            Error as JsonRpseeError, JsonValue,
+        },
+        ws_client::WsClientBuilder,
+    },
+    std::sync::Arc,
+    tokio::sync::{mpsc, oneshot},
+};
+
+const LOG_TARGET: &str = "reconnecting-websocket-client-orchestrator";
+
+type RpcRequestFuture = BoxFuture<'static, Result<(), JsonRpcRequest>>;
+
+/// A Json Rpc/Rpsee request with a oneshot sender to send the request's response.
+pub struct JsonRpcRequest {
+    pub method: String,
+    pub params: ArrayParams,
+    pub response_sender: oneshot::Sender<Result<JsonValue, JsonRpseeError>>,
+}
+
+pub enum WsClientRequest {
+    JsonRpcRequest(JsonRpcRequest),
+    // TODO: Add subscriptions once interface needs it.
+}
+
+enum ConnectionStatus {
+    Connected,
+    Disconnected {
+        failed_request: Option<JsonRpcRequest>,
+    },
+}
+
+/// Worker that manage a WebSocket connection and handle disconnects by changing endpoint and
+/// retrying pending requests.
+///
+/// Is first created with [`ReconnectingWsClientWorker::new`], which returns both a
+/// [`ReconnectingWsClientWorker`] and an [`mpsc::Sender`] to send the requests.
+/// [`ReconnectingWsClientWorker::run`] must the be called and the returned future queued in
+/// a tokio executor.
+pub struct ReconnectingWsClientWorker {
+    urls: Vec<String>,
+    active_client: Arc<JsonRpcClient>,
+    active_index: usize,
+
+    request_receiver: mpsc::Receiver<WsClientRequest>,
+}
+
+/// Connects to a ws server by cycle throught all provided urls from the starting position until
+/// each one one was tried. Stops once a connection was succesfully made.
+async fn connect_next_available_rpc_server(
+    urls: &[String],
+    starting_position: usize,
+) -> Result<(usize, Arc<JsonRpcClient>), ()> {
+    tracing::debug!(target: LOG_TARGET, starting_position, "Connecting to RPC server.");
+
+    for (counter, url) in urls
+        .iter()
+        .cycle()
+        .skip(starting_position)
+        .take(urls.len())
+        .enumerate()
+    {
+        let index = (starting_position + counter) % urls.len();
+
+        tracing::info!(
+            target: LOG_TARGET,
+            index,
+            url,
+            "Trying to connect to next external orchestrator node.",
+        );
+
+        match WsClientBuilder::default().build(&url).await {
+            Ok(ws_client) => return Ok((index, Arc::new(ws_client))),
+            Err(err) => tracing::debug!(target: LOG_TARGET, url, ?err, "Unable to connect."),
+        };
+    }
+    Err(())
+}
+
+impl ReconnectingWsClientWorker {
+    /// Create a new worker that will connect to the provided URLs.
+    pub async fn new(urls: Vec<String>) -> Result<(Self, mpsc::Sender<WsClientRequest>), ()> {
+        if urls.is_empty() {
+            return Err(());
+        }
+
+        let (active_index, active_client) = connect_next_available_rpc_server(&urls, 0).await?;
+        let (request_sender, request_receiver) = mpsc::channel(100);
+
+        Ok((
+            Self {
+                urls,
+                active_client,
+                active_index,
+                request_receiver,
+            },
+            request_sender,
+        ))
+    }
+
+    /// Change RPC server for future requests.
+    async fn connect_to_new_rpc_server(&mut self) -> Result<(), ()> {
+        let (active_index, active_client) =
+            connect_next_available_rpc_server(&self.urls, self.active_index + 1).await?;
+        self.active_index = active_index;
+        self.active_client = active_client;
+        Ok(())
+    }
+
+    /// Send the request to the current client. If this connection becomes dead, the returned future
+    /// will return the request so it can be sent to another client.
+    fn send_request(
+        &self,
+        JsonRpcRequest {
+            method,
+            params,
+            response_sender,
+        }: JsonRpcRequest,
+    ) -> RpcRequestFuture {
+        let client = self.active_client.clone();
+        async move {
+            let response = client.request(&method, params.clone()).await;
+
+            // We should only return the original request in case
+            // the websocket connection is dead and requires a restart.
+            // Other errors should be forwarded to the request caller.
+            if let Err(JsonRpseeError::RestartNeeded(_)) = response {
+                return Err(JsonRpcRequest {
+                    method,
+                    params,
+                    response_sender,
+                });
+            }
+
+            if let Err(err) = response_sender.send(response) {
+                tracing::debug!(
+                    target: LOG_TARGET,
+                    ?err,
+                    "Recipient no longer interested in request result"
+                );
+            }
+
+            Ok(())
+        }
+        .boxed()
+    }
+
+    /// Handle a reconnection by fnding a new RPC server and sending all pending requests.
+    async fn handle_reconnect(
+        &mut self,
+        pending_requests: &mut FuturesUnordered<RpcRequestFuture>,
+        first_failed_request: Option<JsonRpcRequest>,
+    ) -> Result<(), String> {
+        let mut requests_to_retry = Vec::new();
+        if let Some(req) = first_failed_request {
+            requests_to_retry.push(req)
+        }
+
+        // All pending requests will return an error since the websocket connection is dead.
+        // Draining the pending requests should be fast.
+        while !pending_requests.is_empty() {
+            if let Some(Err(req)) = pending_requests.next().await {
+                requests_to_retry.push(req);
+            }
+        }
+
+        // Connect to new RPC server if possible.
+        if self.connect_to_new_rpc_server().await.is_err() {
+            return Err("Unable to find valid external RPC server, shutting down.".to_string());
+        }
+
+        // Retry requests.
+        for req in requests_to_retry.into_iter() {
+            pending_requests.push(self.send_request(req));
+        }
+
+        // TODO: Add subscriptions once interface needs it.
+
+        Ok(())
+    }
+
+    pub async fn run(mut self) {
+        let mut pending_requests = FuturesUnordered::new();
+        let mut connection_status = ConnectionStatus::Connected;
+
+        loop {
+            // Handle reconnection.
+            if let ConnectionStatus::Disconnected { failed_request } = connection_status {
+                if let Err(message) = self
+                    .handle_reconnect(&mut pending_requests, failed_request)
+                    .await
+                {
+                    tracing::error!(
+                        target: LOG_TARGET,
+                        message,
+                        "Unable to reconnect, stopping worker."
+                    );
+                    return;
+                }
+
+                connection_status = ConnectionStatus::Connected;
+            }
+
+            tokio::select! {
+                // New request received.
+                req = self.request_receiver.recv() => match req {
+                    Some(WsClientRequest::JsonRpcRequest(req)) => {
+                        pending_requests.push(self.send_request(req));
+                    },
+                    None => {
+                        tracing::error!(target: LOG_TARGET, "RPC client receiver closed. Stopping RPC Worker.");
+                        return;
+                    }
+                },
+                // We poll pending request futures. If one completes with an `Err`, it means the
+                // ws client was disconnected and we need to reconnect to a new ws client.
+                pending = pending_requests.next(), if !pending_requests.is_empty() => {
+                    if let Some(Err(req)) = pending {
+                        connection_status = ConnectionStatus::Disconnected { failed_request: Some(req) };
+                    }
+                },
+                // TODO: Add subscriptions once interface needs it.
+            }
+        }
+    }
+}

--- a/container-chain-pallets/authorities-noting/Cargo.toml
+++ b/container-chain-pallets/authorities-noting/Cargo.toml
@@ -68,11 +68,11 @@ std = [
 	"dp-chain-state-snapshot/std",
 	"dp-collator-assignment/std",
 	"dp-core/std",
- ]
+]
 runtime-benchmarks = [
 	"cumulus-pallet-parachain-system/runtime-benchmarks",
 	"frame-benchmarking",
 	"hex",
-	"nimbus-primitives/runtime-benchmarks"
+	"nimbus-primitives/runtime-benchmarks",
 ]
 try-runtime = [ "frame-support/try-runtime" ]

--- a/container-chain-pallets/authorities-noting/src/benchmarks.rs
+++ b/container-chain-pallets/authorities-noting/src/benchmarks.rs
@@ -22,6 +22,8 @@ use {
     cumulus_pallet_parachain_system::RelaychainStateProvider,
     frame_benchmarking::{account, benchmarks},
     frame_system::RawOrigin,
+    nimbus_primitives::NimbusId,
+    sp_core::crypto::ByteArray,
     sp_std::{vec, vec::Vec},
 };
 
@@ -120,8 +122,6 @@ impl<AuthorityId> BenchmarkHelper<AuthorityId> for () {
 
 pub struct NimbusIdBenchmarkHelper;
 
-use nimbus_primitives::NimbusId;
-use sp_core::crypto::ByteArray;
 impl<AuthorityId: From<NimbusId>> BenchmarkHelper<AuthorityId> for NimbusIdBenchmarkHelper {
     fn authorities_on_empty() -> Vec<AuthorityId> {
         vec![NimbusId::from_slice(&[1; 32]).unwrap().into()]

--- a/container-chain-primitives/authorities-noting-inherent/Cargo.toml
+++ b/container-chain-primitives/authorities-noting-inherent/Cargo.toml
@@ -11,10 +11,10 @@ parity-scale-codec = { workspace = true, features = [ "derive", "max-encoded-len
 scale-info = { workspace = true }
 tracing = { workspace = true, optional = true }
 
-test-relay-sproof-builder = { workspace = true, optional = true }
+dc-orchestrator-chain-interface = { workspace = true, optional = true }
 dp-collator-assignment = { workspace = true, optional = true }
 dp-core = { workspace = true, optional = true }
-dc-orchestrator-chain-interface = { workspace = true, optional = true }
+test-relay-sproof-builder = { workspace = true, optional = true }
 
 # Substrate
 sp-consensus-aura = { workspace = true, optional = true }

--- a/container-chain-primitives/authorities-noting-inherent/src/tests.rs
+++ b/container-chain-primitives/authorities-noting-inherent/src/tests.rs
@@ -110,6 +110,24 @@ impl OrchestratorChainInterface for DummyOrchestratorChainInterface {
             .unwrap()
             .map_err(|e| e.into())
     }
+
+    async fn import_notification_stream(
+        &self,
+    ) -> OrchestratorChainResult<Pin<Box<dyn Stream<Item = PHeader> + Send>>> {
+        unimplemented!("Not needed for test")
+    }
+
+    async fn new_best_notification_stream(
+        &self,
+    ) -> OrchestratorChainResult<Pin<Box<dyn Stream<Item = PHeader> + Send>>> {
+        unimplemented!("Not needed for test")
+    }
+
+    async fn finality_notification_stream(
+        &self,
+    ) -> OrchestratorChainResult<Pin<Box<dyn Stream<Item = PHeader> + Send>>> {
+        unimplemented!("Not needed for test")
+    }
 }
 
 #[async_trait]

--- a/pallets/xcm-executor-utils/Cargo.toml
+++ b/pallets/xcm-executor-utils/Cargo.toml
@@ -7,17 +7,17 @@ license = "GPL-3.0-only"
 version = "0.1.0"
 
 [package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
+targets = [ "x86_64-unknown-linux-gnu" ]
 
 [dependencies]
-serde = { workspace = true, features = ["derive"] }
+serde = { workspace = true, features = [ "derive" ] }
 
 frame-benchmarking = { workspace = true, optional = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 parity-scale-codec = { workspace = true, features = [
-    "derive",
-    "max-encoded-len",
+	"derive",
+	"max-encoded-len",
 ] }
 scale-info = { workspace = true }
 sp-core = { workspace = true }
@@ -27,23 +27,23 @@ sp-std = { workspace = true }
 staging-xcm = { workspace = true }
 
 [features]
-default = ["std"]
+default = [ "std" ]
 std = [
-    "frame-benchmarking/std",
-    "frame-support/std",
-    "frame-system/std",
-    "parity-scale-codec/std",
-    "scale-info/std",
-    "serde/std",
-    "sp-runtime/std",
-    "sp-std/std",
-    "staging-xcm/std",
+	"frame-benchmarking/std",
+	"frame-support/std",
+	"frame-system/std",
+	"parity-scale-codec/std",
+	"scale-info/std",
+	"serde/std",
+	"sp-runtime/std",
+	"sp-std/std",
+	"staging-xcm/std",
 ]
 runtime-benchmarks = [
-    "frame-benchmarking",
-    "frame-benchmarking/runtime-benchmarks",
-    "frame-support/runtime-benchmarks",
-    "frame-system/runtime-benchmarks",
-    "sp-runtime/runtime-benchmarks",
+	"frame-benchmarking",
+	"frame-benchmarking/runtime-benchmarks",
+	"frame-support/runtime-benchmarks",
+	"frame-system/runtime-benchmarks",
+	"sp-runtime/runtime-benchmarks",
 ]
 try-runtime = [ "frame-support/try-runtime" ]

--- a/pallets/xcm-executor-utils/src/lib.rs
+++ b/pallets/xcm-executor-utils/src/lib.rs
@@ -46,9 +46,7 @@ use {
 
 #[frame_support::pallet]
 pub mod pallet {
-    use super::*;
-    use sp_runtime::BoundedVec;
-    use sp_std::vec::Vec;
+    use {super::*, sp_runtime::BoundedVec, sp_std::vec::Vec};
 
     // Default trust policies for incoming assets
     #[derive(

--- a/primitives/collator-assignment/Cargo.toml
+++ b/primitives/collator-assignment/Cargo.toml
@@ -33,4 +33,15 @@ polkadot-primitives = { workspace = true, optional = true }
 
 [features]
 default = [ "std" ]
-std = [ "cumulus-primitives-core/std", "frame-support/std", "parity-scale-codec/std", "polkadot-primitives", "serde/std", "sp-core/std", "sp-runtime/std", "sp-state-machine/std", "sp-std/std", "sp-trie/std"]
+std = [
+	"cumulus-primitives-core/std",
+	"frame-support/std",
+	"parity-scale-codec/std",
+	"polkadot-primitives",
+	"serde/std",
+	"sp-core/std",
+	"sp-runtime/std",
+	"sp-state-machine/std",
+	"sp-std/std",
+	"sp-trie/std",
+]

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -12,16 +12,22 @@ targets = [ "x86_64-unknown-linux-gnu" ]
 hex-literal = { workspace = true }
 
 # Substrate
+frame-support = { workspace = true }
 parity-scale-codec = { workspace = true }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
 sp-std = { workspace = true }
-frame-support = { workspace = true }
 
 # Cumulus
 cumulus-primitives-core = { workspace = true }
 
 [features]
 default = [ "std" ]
-std = [ "cumulus-primitives-core/std", "parity-scale-codec/std", "sp-core/std", "sp-io/std", "sp-std/std" ]
+std = [
+	"cumulus-primitives-core/std",
+	"parity-scale-codec/std",
+	"sp-core/std",
+	"sp-io/std",
+	"sp-std/std",
+]

--- a/test-sproof-builder/Cargo.toml
+++ b/test-sproof-builder/Cargo.toml
@@ -4,9 +4,9 @@ authors = []
 edition = "2021"
 version = "0.1.0"
 [dependencies]
-parity-scale-codec = { workspace = true, optional = true, features = [ "derive", "max-encoded-len" ] }
 dp-collator-assignment = { workspace = true, optional = true }
 dp-core = { workspace = true, optional = true }
+parity-scale-codec = { workspace = true, optional = true, features = [ "derive", "max-encoded-len" ] }
 
 # Substrate
 frame-support = { workspace = true, optional = true }
@@ -19,4 +19,13 @@ cumulus-primitives-core = { workspace = true, optional = true }
 
 [features]
 default = [ "std" ]
-std = [ "cumulus-primitives-core/std", "frame-support/std", "parity-scale-codec/std", "sp-runtime/std", "sp-state-machine/std", "sp-trie/std", "dp-collator-assignment/std", "dp-core/std" ]
+std = [
+	"cumulus-primitives-core/std",
+	"frame-support/std",
+	"parity-scale-codec/std",
+	"sp-runtime/std",
+	"sp-state-machine/std",
+	"sp-trie/std",
+	"dp-collator-assignment/std",
+	"dp-core/std",
+]


### PR DESCRIPTION
Implements our `OrchestratorChainInterface` trait with an RPC client, in a similar way as `cumulus-relay-chain-rpc-interface`.

I followed the implementation from cumulus but simplified a bit the code, and didn't included yet any subscriber (since our interface don't include it). This can be added in a later PR, and will be required for data providers to know when new blocks are produced so that they can read their assignment in real-time.