### PR TITLE
export weights properly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2160,7 +2160,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
+ "sp-std 8.0.0",
 ]
 
 [[package]]

--- a/container-chain-pallets/authorities-noting/src/lib.rs
+++ b/container-chain-pallets/authorities-noting/src/lib.rs
@@ -34,6 +34,7 @@ mod mock;
 #[cfg(test)]
 mod tests;
 pub mod weights;
+pub use weights::WeightInfo;
 
 #[cfg(any(test, feature = "runtime-benchmarks"))]
 pub mod benchmarks;
@@ -45,7 +46,6 @@ use crate::benchmarks::BenchmarkHelper;
 pub use pallet::*;
 
 use {
-    crate::weights::WeightInfo,
     ccp_authorities_noting_inherent::INHERENT_IDENTIFIER,
     cumulus_pallet_parachain_system::RelaychainStateProvider,
     cumulus_primitives_core::{

--- a/pallets/xcm-executor-utils/src/lib.rs
+++ b/pallets/xcm-executor-utils/src/lib.rs
@@ -28,6 +28,7 @@ mod mock;
 #[cfg(test)]
 mod tests;
 pub mod weights;
+pub use weights::WeightInfo;
 
 #[cfg(any(test, feature = "runtime-benchmarks"))]
 mod benchmarks;
@@ -37,7 +38,6 @@ pub mod filters;
 pub use pallet::*;
 
 use {
-    crate::weights::WeightInfo,
     frame_support::{pallet_prelude::*, DefaultNoBound},
     frame_system::pallet_prelude::*,
     serde::{Deserialize, Serialize},


### PR DESCRIPTION
Exports the weightInfo struct to make it accessible for benchmarks from runtimes