### PR TITLE
Add registrar->paras key

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.77.0"
+channel = "1.78.0"
 components = [ "rustfmt", "clippy", "rust-src" ]
 targets = [ "wasm32-unknown-unknown" ]
 profile = "minimal"


### PR DESCRIPTION
And update to Rust 1.78

registrar->paras and `ParaInfo` will be used in https://github.com/moondance-labs/tanssi/pull/553