### PR TITLE
add authorities and min_slot_freq fn to interface

### DIFF
--- a/client/orchestrator-chain-rpc-interface/src/lib.rs
+++ b/client/orchestrator-chain-rpc-interface/src/lib.rs
@@ -251,8 +251,8 @@ impl<T: Sync + Send + Decode> OrchestratorChainInterface for OrchestratorChainRp
         relevant_keys: &[Vec<u8>],
     ) -> OrchestratorChainResult<StorageProof> {
         let mut cloned = Vec::new();
-        cloned.extend_from_slice(&relevant_keys);
-        let storage_keys: Vec<StorageKey> = cloned.into_iter().map(|key| StorageKey(key)).collect();
+        cloned.extend_from_slice(relevant_keys);
+        let storage_keys: Vec<StorageKey> = cloned.into_iter().map(StorageKey).collect();
 
         self.state_get_read_proof(storage_keys, Some(orchestrator_parent))
             .await

--- a/client/orchestrator-chain-rpc-interface/src/lib.rs
+++ b/client/orchestrator-chain-rpc-interface/src/lib.rs
@@ -18,10 +18,12 @@ mod ws_client;
 
 use {
     async_trait::async_trait,
-    core::pin::Pin,
+    core::{marker::PhantomData, pin::Pin},
     dc_orchestrator_chain_interface::{
-        OrchestratorChainError, OrchestratorChainInterface, OrchestratorChainResult, PHash, PHeader,
+        OrchestratorChainError, OrchestratorChainInterface, OrchestratorChainResult, PHash,
+        PHeader, Slot,
     },
+    dp_core::ParaId,
     futures::{Stream, StreamExt},
     jsonrpsee::{core::params::ArrayParams, rpc_params},
     sc_client_api::{StorageData, StorageProof},
@@ -60,11 +62,11 @@ fn url_to_string_with_port(url: Url) -> Option<String> {
     ))
 }
 
-pub async fn create_client_and_start_worker(
+pub async fn create_client_and_start_worker<T>(
     urls: Vec<Url>,
     task_manager: &mut TaskManager,
     overseer_handle: Option<polkadot_overseer::Handle>,
-) -> OrchestratorChainResult<OrchestratorChainRpcClient> {
+) -> OrchestratorChainResult<OrchestratorChainRpcClient<T>> {
     let urls: Vec<_> = urls
         .into_iter()
         .filter_map(url_to_string_with_port)
@@ -84,18 +86,20 @@ pub async fn create_client_and_start_worker(
     let client = OrchestratorChainRpcClient {
         request_sender,
         overseer_handle,
+        _phantom: PhantomData,
     };
 
     Ok(client)
 }
 
 #[derive(Clone)]
-pub struct OrchestratorChainRpcClient {
+pub struct OrchestratorChainRpcClient<T> {
     request_sender: mpsc::Sender<WsClientRequest>,
     overseer_handle: Option<polkadot_overseer::Handle>,
+    _phantom: PhantomData<T>,
 }
 
-impl OrchestratorChainRpcClient {
+impl<T> OrchestratorChainRpcClient<T> {
     /// Call a call to `state_call` rpc method.
     pub async fn call_remote_runtime_function<R: Decode>(
         &self,
@@ -216,7 +220,9 @@ impl OrchestratorChainRpcClient {
 }
 
 #[async_trait]
-impl OrchestratorChainInterface for OrchestratorChainRpcClient {
+impl<T: Sync + Send + Decode> OrchestratorChainInterface for OrchestratorChainRpcClient<T> {
+    type AuthorityId = T;
+
     /// Fetch a storage item by key.
     async fn get_storage_by_key(
         &self,
@@ -280,5 +286,30 @@ impl OrchestratorChainInterface for OrchestratorChainRpcClient {
         let rx = self.send_register_message(WsClientRequest::RegisterFinalizationListener)?;
         let stream = tokio_stream::wrappers::ReceiverStream::new(rx);
         Ok(stream.boxed())
+    }
+
+    /// Return the set of authorities assigned to the paraId where
+    /// the first eligible key from the keystore is collating
+    async fn authorities(
+        &self,
+        orchestrator_parent: PHash,
+        para_id: ParaId,
+    ) -> OrchestratorChainResult<Option<Vec<Self::AuthorityId>>> {
+        self.call_remote_runtime_function("para_id_authorities", orchestrator_parent, Some(para_id))
+            .await
+    }
+
+    /// Returns the minimum slot frequency for this para id.
+    async fn min_slot_freq(
+        &self,
+        orchestrator_parent: PHash,
+        para_id: ParaId,
+    ) -> OrchestratorChainResult<Option<Slot>> {
+        self.call_remote_runtime_function(
+            "parathread_slot_frequency",
+            orchestrator_parent,
+            Some(para_id),
+        )
+        .await
     }
 }

--- a/container-chain-pallets/authorities-noting/src/benchmarks.rs
+++ b/container-chain-pallets/authorities-noting/src/benchmarks.rs
@@ -69,8 +69,8 @@ mod test_sproof {
 benchmarks! {
     set_latest_authorities_data {
         // TODO: this could measure the proof size
-        let sproof_builder_relay = test_sproof::ParaHeaderSproofBuilder::default();
-        let sproof_builder_orchestrator = test_sproof::AuthorityAssignmentSproofBuilder::default();
+        let sproof_builder_relay = test_sproof::ParaHeaderSproofBuilder;
+        let sproof_builder_orchestrator = test_sproof::AuthorityAssignmentSproofBuilder;
 
         let (relay_root, relay_proof) = sproof_builder_relay.into_state_root_and_proof();
         let (orchestrator_root, orchestrator_proof) = sproof_builder_orchestrator.into_state_root_and_proof();

--- a/container-chain-pallets/authorities-noting/src/tests.rs
+++ b/container-chain-pallets/authorities-noting/src/tests.rs
@@ -41,7 +41,7 @@ fn genesis_config_orchestrator_para_id() {
 fn genesis_config_orchestrator_para_id_storage_update() {
     new_test_ext().execute_with(|| {
         let new_para_id = ParaId::new(2000);
-        OrchestratorParaId::<Test>::put(&new_para_id);
+        OrchestratorParaId::<Test>::put(new_para_id);
         assert_eq!(OrchestratorParaId::<Test>::get(), new_para_id);
     });
 }

--- a/container-chain-primitives/authorities-noting-inherent/src/tests.rs
+++ b/container-chain-primitives/authorities-noting-inherent/src/tests.rs
@@ -26,7 +26,7 @@ use {
         InboundDownwardMessage, InboundHrmpMessage, ParaId, PersistedValidationData,
     },
     cumulus_relay_chain_interface::{PHash, PHeader, RelayChainInterface, RelayChainResult},
-    dc_orchestrator_chain_interface::{OrchestratorChainInterface, OrchestratorChainResult},
+    dc_orchestrator_chain_interface::{OrchestratorChainInterface, OrchestratorChainResult, Slot},
     dp_core::{well_known_keys, Header as OrchestratorHeader},
     futures::Stream,
     polkadot_overseer::Handle,
@@ -84,6 +84,8 @@ impl DummyRelayChainInterface {
 
 #[async_trait]
 impl OrchestratorChainInterface for DummyOrchestratorChainInterface {
+    type AuthorityId = ();
+
     fn overseer_handle(&self) -> OrchestratorChainResult<Handle> {
         unimplemented!("Not needed for test")
     }
@@ -94,7 +96,7 @@ impl OrchestratorChainInterface for DummyOrchestratorChainInterface {
         key: &[u8],
     ) -> OrchestratorChainResult<Option<StorageValue>> {
         self.orchestrator_client
-            .storage(hash.into(), &StorageKey(key.to_vec()))
+            .storage(hash, &StorageKey(key.to_vec()))
             .map(|a| a.map(|b| b.0))
             .map_err(|e| e.into())
     }
@@ -126,6 +128,22 @@ impl OrchestratorChainInterface for DummyOrchestratorChainInterface {
     async fn finality_notification_stream(
         &self,
     ) -> OrchestratorChainResult<Pin<Box<dyn Stream<Item = PHeader> + Send>>> {
+        unimplemented!("Not needed for test")
+    }
+
+    async fn authorities(
+        &self,
+        _orchestrator_parent: PHash,
+        _para_id: ParaId,
+    ) -> OrchestratorChainResult<Option<Vec<Self::AuthorityId>>> {
+        unimplemented!("Not needed for test")
+    }
+
+    async fn min_slot_freq(
+        &self,
+        _orchestrator_parent: PHash,
+        _para_id: ParaId,
+    ) -> OrchestratorChainResult<Option<Slot>> {
         unimplemented!("Not needed for test")
     }
 }
@@ -218,7 +236,7 @@ impl RelayChainInterface for DummyRelayChainInterface {
     ) -> RelayChainResult<Option<StorageValue>> {
         Ok(self
             .relay_client
-            .storage(hash.into(), &StorageKey(key.to_vec()))
+            .storage(hash, &StorageKey(key.to_vec()))
             .map(|a| a.map(|b| b.0))
             .unwrap())
     }

--- a/pallets/xcm-executor-utils/src/benchmarks.rs
+++ b/pallets/xcm-executor-utils/src/benchmarks.rs
@@ -115,5 +115,9 @@ mod benchmarks {
         Ok(())
     }
 
-    impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Test);
+    impl_benchmark_test_suite!(
+        Pallet,
+        crate::mock::mock_never::new_test_ext(),
+        crate::mock::mock_never::TestNever
+    );
 }

--- a/pallets/xcm-executor-utils/src/filters.rs
+++ b/pallets/xcm-executor-utils/src/filters.rs
@@ -174,14 +174,13 @@ mod test {
             fun: Fungible(1_000),
         };
 
-        assert_eq!(
-            apply_policy::<TestAllNative>(
+        assert!(
+            !apply_policy::<TestAllNative>(
                 &grandparent_asset,
                 &parent_location,
                 None,
                 <TestAllNative as Config>::ReserveDefaultTrustPolicy::get(),
-            ),
-            false
+            )
         );
     }
 
@@ -193,14 +192,13 @@ mod test {
             fun: Fungible(1_000),
         };
 
-        assert_eq!(
-            apply_policy::<TestNever>(
+        assert!(
+            !apply_policy::<TestNever>(
                 &parent_asset,
                 &parent_location,
                 None,
                 <TestNever as Config>::ReserveDefaultTrustPolicy::get(),
-            ),
-            false
+            )
         );
     }
 
@@ -260,14 +258,13 @@ mod test {
             DefaultTrustPolicy::AllNative,
         ));
 
-        assert_eq!(
-            apply_policy::<TestNever>(
+        assert!(
+            !apply_policy::<TestNever>(
                 &grandparent_asset,
                 &parent_location,
                 origin_policy,
                 default_policy
-            ),
-            false
+            )
         );
     }
 
@@ -314,14 +311,13 @@ mod test {
         ));
 
         // parent_asset should be rejected
-        assert_eq!(
-            apply_policy::<TestNever>(
+        assert!(
+            !apply_policy::<TestNever>(
                 &parent_asset,
                 &parent_location,
                 origin_policy,
                 default_policy
-            ),
-            false
+            )
         );
     }
 }

--- a/pallets/xcm-executor-utils/src/filters.rs
+++ b/pallets/xcm-executor-utils/src/filters.rs
@@ -174,14 +174,12 @@ mod test {
             fun: Fungible(1_000),
         };
 
-        assert!(
-            !apply_policy::<TestAllNative>(
-                &grandparent_asset,
-                &parent_location,
-                None,
-                <TestAllNative as Config>::ReserveDefaultTrustPolicy::get(),
-            )
-        );
+        assert!(!apply_policy::<TestAllNative>(
+            &grandparent_asset,
+            &parent_location,
+            None,
+            <TestAllNative as Config>::ReserveDefaultTrustPolicy::get(),
+        ));
     }
 
     #[test]
@@ -192,14 +190,12 @@ mod test {
             fun: Fungible(1_000),
         };
 
-        assert!(
-            !apply_policy::<TestNever>(
-                &parent_asset,
-                &parent_location,
-                None,
-                <TestNever as Config>::ReserveDefaultTrustPolicy::get(),
-            )
-        );
+        assert!(!apply_policy::<TestNever>(
+            &parent_asset,
+            &parent_location,
+            None,
+            <TestNever as Config>::ReserveDefaultTrustPolicy::get(),
+        ));
     }
 
     #[test]
@@ -258,14 +254,12 @@ mod test {
             DefaultTrustPolicy::AllNative,
         ));
 
-        assert!(
-            !apply_policy::<TestNever>(
-                &grandparent_asset,
-                &parent_location,
-                origin_policy,
-                default_policy
-            )
-        );
+        assert!(!apply_policy::<TestNever>(
+            &grandparent_asset,
+            &parent_location,
+            origin_policy,
+            default_policy
+        ));
     }
 
     #[test]
@@ -311,13 +305,11 @@ mod test {
         ));
 
         // parent_asset should be rejected
-        assert!(
-            !apply_policy::<TestNever>(
-                &parent_asset,
-                &parent_location,
-                origin_policy,
-                default_policy
-            )
-        );
+        assert!(!apply_policy::<TestNever>(
+            &parent_asset,
+            &parent_location,
+            origin_policy,
+            default_policy
+        ));
     }
 }

--- a/pallets/xcm-executor-utils/src/migrations.rs
+++ b/pallets/xcm-executor-utils/src/migrations.rs
@@ -14,18 +14,20 @@
 // You should have received a copy of the GNU General Public License
 // along with Tanssi.  If not, see <http://www.gnu.org/licenses/>.
 
-use super::*;
-use frame_support::migration::storage_key_iter;
-use frame_support::traits::OnRuntimeUpgrade;
-use sp_std::vec::Vec;
+use {
+    super::*,
+    frame_support::{migration::storage_key_iter, traits::OnRuntimeUpgrade},
+    sp_std::vec::Vec,
+};
 /// The in-code storage version.
 pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
 
 pub mod v1 {
-    use frame_support::pallet_prelude::*;
-    use sp_std::vec::Vec;
-    use staging_xcm::latest::AssetId;
-    use staging_xcm::v3::AssetId as OldAssetId;
+    use {
+        frame_support::pallet_prelude::*,
+        sp_std::vec::Vec,
+        staging_xcm::{latest::AssetId, v3::AssetId as OldAssetId},
+    };
 
     use crate::TrustPolicy;
 

--- a/pallets/xcm-executor-utils/src/migrations.rs
+++ b/pallets/xcm-executor-utils/src/migrations.rs
@@ -47,16 +47,16 @@ pub mod v1 {
         AllowedAssets(BoundedVec<OldAssetId, MaxAssets>),
     }
 
-    impl<MaxAssets: Get<u32>> Into<TrustPolicy<MaxAssets>> for OldTrustPolicy<MaxAssets> {
-        fn into(self) -> TrustPolicy<MaxAssets> {
-            match self {
+    impl<MaxAssets: Get<u32>> From<OldTrustPolicy<MaxAssets>> for TrustPolicy<MaxAssets> {
+        fn from(val: OldTrustPolicy<MaxAssets>) -> Self {
+            match val {
                 OldTrustPolicy::DefaultTrustPolicy(default_policy) => {
                     TrustPolicy::DefaultTrustPolicy(default_policy)
                 }
                 OldTrustPolicy::AllowedAssets(old_assets) => {
                     let new_assets: Vec<AssetId> = old_assets
                         .iter()
-                        .filter_map(|old_asset| AssetId::try_from(old_asset.clone()).ok())
+                        .filter_map(|old_asset| AssetId::try_from(*old_asset).ok())
                         .collect();
                     TrustPolicy::AllowedAssets(
                         new_assets

--- a/pallets/xcm-executor-utils/src/tests.rs
+++ b/pallets/xcm-executor-utils/src/tests.rs
@@ -153,11 +153,13 @@ fn teleport_policy_is_applied() {
 #[test]
 fn test_v1_migration() {
     new_test_ext().execute_with(|| {
-        use frame_support::storage::migration::put_storage_value;
-        use frame_support::traits::OnRuntimeUpgrade;
-        use frame_support::StorageHasher;
-        use frame_support::StoragePrefixedMap;
-        use staging_xcm::v3::{AssetId as OldAssetId, MultiLocation as OldLocation};
+        use {
+            frame_support::{
+                storage::migration::put_storage_value, traits::OnRuntimeUpgrade, StorageHasher,
+                StoragePrefixedMap,
+            },
+            staging_xcm::v3::{AssetId as OldAssetId, MultiLocation as OldLocation},
+        };
         let pallet_prefix = ReservePolicy::<TestNever>::pallet_prefix();
         let reserve_policy_storage_prefix = ReservePolicy::<TestNever>::storage_prefix();
         let teleport_policy_storage_prefix = TeleportPolicy::<TestNever>::storage_prefix();

--- a/pallets/xcm-executor-utils/src/tests.rs
+++ b/pallets/xcm-executor-utils/src/tests.rs
@@ -105,9 +105,8 @@ fn reserve_policy_is_applied() {
         ));
 
         // Should reject parent_asset
-        assert_eq!(
-            IsReserveFilter::<TestNever>::contains(&parent_asset, &parent_location),
-            false
+        assert!(
+            !IsReserveFilter::<TestNever>::contains(&parent_asset, &parent_location)
         );
     });
 }
@@ -143,9 +142,8 @@ fn teleport_policy_is_applied() {
         ),);
 
         // Should reject parent_asset
-        assert_eq!(
-            IsTeleportFilter::<TestNever>::contains(&parent_asset, &parent_location),
-            false
+        assert!(
+            !IsTeleportFilter::<TestNever>::contains(&parent_asset, &parent_location)
         );
     });
 }

--- a/pallets/xcm-executor-utils/src/tests.rs
+++ b/pallets/xcm-executor-utils/src/tests.rs
@@ -105,9 +105,10 @@ fn reserve_policy_is_applied() {
         ));
 
         // Should reject parent_asset
-        assert!(
-            !IsReserveFilter::<TestNever>::contains(&parent_asset, &parent_location)
-        );
+        assert!(!IsReserveFilter::<TestNever>::contains(
+            &parent_asset,
+            &parent_location
+        ));
     });
 }
 
@@ -142,9 +143,10 @@ fn teleport_policy_is_applied() {
         ),);
 
         // Should reject parent_asset
-        assert!(
-            !IsTeleportFilter::<TestNever>::contains(&parent_asset, &parent_location)
-        );
+        assert!(!IsTeleportFilter::<TestNever>::contains(
+            &parent_asset,
+            &parent_location
+        ));
     });
 }
 

--- a/primitives/slot-duration-runtime-api/Cargo.toml
+++ b/primitives/slot-duration-runtime-api/Cargo.toml
@@ -17,6 +17,7 @@ sp-core = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
 sp-std = { workspace = true }
+
 # Cumulus
 cumulus-primitives-core = { workspace = true }
 


### PR DESCRIPTION
Add new functions to the interface which proxies runtime APIs required to spawn container chain embeded nodes. This is required for data providers nodes without embeded Tanssi node (connection through websocket) to be able to spawn container chain embeded nodes.