### PR TITLE
Add new fns to `OrchestratorChainInterface` to fetch best/finalized block hash

### DIFF
--- a/client/orchestrator-chain-interface/src/lib.rs
+++ b/client/orchestrator-chain-interface/src/lib.rs
@@ -143,6 +143,10 @@ pub trait OrchestratorChainInterface: Send + Sync {
         orchestrator_parent: PHash,
         para_id: ParaId,
     ) -> OrchestratorChainResult<Option<BlockNumber>>;
+
+    async fn best_block_hash(&self) -> OrchestratorChainResult<PHash>;
+
+    async fn finalized_block_hash(&self) -> OrchestratorChainResult<PHash>;
 }
 
 #[async_trait::async_trait]
@@ -214,5 +218,13 @@ where
         (**self)
             .latest_block_number(orchestrator_parent, para_id)
             .await
+    }
+
+    async fn best_block_hash(&self) -> OrchestratorChainResult<PHash> {
+        (**self).best_block_hash().await
+    }
+
+    async fn finalized_block_hash(&self) -> OrchestratorChainResult<PHash> {
+        (**self).finalized_block_hash().await
     }
 }

--- a/container-chain-primitives/authorities-noting-inherent/src/tests.rs
+++ b/container-chain-primitives/authorities-noting-inherent/src/tests.rs
@@ -154,6 +154,14 @@ impl OrchestratorChainInterface for DummyOrchestratorChainInterface {
     ) -> OrchestratorChainResult<Option<BlockNumber>> {
         unimplemented!("Not needed for test")
     }
+
+    async fn best_block_hash(&self) -> OrchestratorChainResult<PHash> {
+        unimplemented!("Not needed for test")
+    }
+
+    async fn finalized_block_hash(&self) -> OrchestratorChainResult<PHash> {
+        unimplemented!("Not needed for test")
+    }
 }
 
 #[async_trait]


### PR DESCRIPTION
They are required to get a recent block to spawn a container chain embeded node, which was currently not possible without a client.