### PR TITLE
Implement solochain state proofs

### DIFF
--- a/container-chain-pallets/authorities-noting/src/tests.rs
+++ b/container-chain-pallets/authorities-noting/src/tests.rs
@@ -115,6 +115,25 @@ fn test_authorities_insertion_wrong_para_id() {
 }
 
 #[test]
+fn test_authorities_insertion_right_para_id_solochain() {
+    let mut assignment = AuthorityAssignmentSproofBuilder::<u64>::default();
+    assignment
+        .authority_assignment
+        .container_chains
+        .insert(ParachainId::get(), vec![10u64, 11u64]);
+
+    let (orchestrator_chain_root, orchestrator_chain_state) =
+        assignment.into_state_root_and_proof_solochain();
+
+    BlockTests::new()
+        .with_relay_storage_proof(orchestrator_chain_root, orchestrator_chain_state)
+        .with_orchestrator_storage_proof(sp_trie::StorageProof::empty())
+        .add(1, || {
+            assert_eq!(AuthoritiesNoting::authorities(), vec![10u64, 11u64]);
+        });
+}
+
+#[test]
 #[should_panic(
     expected = "Orchestrator chain authorities data needs to be present in every block!"
 )]

--- a/primitives/core/src/lib.rs
+++ b/primitives/core/src/lib.rs
@@ -96,12 +96,22 @@ pub mod well_known_keys {
         })
     }
 
+    /// authorityAssignment pallet prefix
     pub const AUTHORITY_ASSIGNMENT_PREFIX: &[u8] =
         &hex_literal::hex!["ebe78423c7e3ed25234f80d54547285a170f16afec7d161bc6acec3964492a0c"];
 
-    pub fn authority_assignment_for_session(session_index: u32) -> Vec<u8> {
+    /// tanssiAuthorityAssignment instead of authorityAssignment for solochain
+    pub const SOLOCHAIN_AUTHORITY_ASSIGNMENT_PREFIX: &[u8] =
+        &hex_literal::hex!["7a201242ca61564279dc11734e3f8772170f16afec7d161bc6acec3964492a0c"];
+
+    pub fn authority_assignment_for_session(
+        session_index: u32,
+        custom_prefix: Option<&[u8]>,
+    ) -> Vec<u8> {
         session_index.using_encoded(|index| {
-            AUTHORITY_ASSIGNMENT_PREFIX
+            let prefix = custom_prefix.unwrap_or(AUTHORITY_ASSIGNMENT_PREFIX);
+
+            prefix
                 .iter()
                 .chain(twox_64(index).iter())
                 .chain(index.iter())

--- a/test-sproof-builder/src/lib.rs
+++ b/test-sproof-builder/src/lib.rs
@@ -200,7 +200,7 @@ impl<T: Encode> AuthorityAssignmentSproofBuilder<T> {
             self.session_index.encode(),
         );
         insert(
-            well_known_keys::authority_assignment_for_session(self.session_index).to_vec(),
+            well_known_keys::authority_assignment_for_session(self.session_index, None).to_vec(),
             self.authority_assignment.encode(),
         );
 


### PR DESCRIPTION
Add function `ContainerChainAuthoritiesInherentData::create_at_solochain` to allow collators to create a storage proof for container chains running under a solochain.

And modify pallet-authorities-noting to support storage proofs from both dancebox and starlight. Starlight proofs are identified by having an empty `orchestrator_chain_state_proof`.