### PR TITLE
Use same type as in RelayChainInterface

### DIFF
--- a/client/orchestrator-chain-interface/src/lib.rs
+++ b/client/orchestrator-chain-interface/src/lib.rs
@@ -108,7 +108,7 @@ pub trait OrchestratorChainInterface: Send + Sync {
     async fn prove_read(
         &self,
         orchestrator_parent: PHash,
-        relevant_keys: &[Vec<u8>],
+        relevant_keys: &Vec<Vec<u8>>,
     ) -> OrchestratorChainResult<StorageProof>;
 
     /// Get a stream of import block notifications.
@@ -169,7 +169,7 @@ where
     async fn prove_read(
         &self,
         orchestrator_parent: PHash,
-        relevant_keys: &[Vec<u8>],
+        relevant_keys: &Vec<Vec<u8>>,
     ) -> OrchestratorChainResult<StorageProof> {
         (**self)
             .prove_read(orchestrator_parent, relevant_keys)

--- a/container-chain-primitives/authorities-noting-inherent/src/tests.rs
+++ b/container-chain-primitives/authorities-noting-inherent/src/tests.rs
@@ -105,7 +105,7 @@ impl OrchestratorChainInterface for DummyOrchestratorChainInterface {
     async fn prove_read(
         &self,
         hash: PHash,
-        keys: &[Vec<u8>],
+        keys: &Vec<Vec<u8>>,
     ) -> OrchestratorChainResult<sc_client_api::StorageProof> {
         self.orchestrator_client
             .state_at(hash)


### PR DESCRIPTION
I need this to be able to use `RelayChainInterface::prove_read` to implement `OrchestratorChainInterface::prove_read`. Using `&Vec` as input argument is never correct, but we are forced to do it here.