### PR TITLE
Add `data_preserver_active_assignment` fn to `OrchestratorChainInterface`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1684,6 +1684,7 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-overseer",
  "sc-client-api",
+ "serde",
  "sp-api",
  "sp-blockchain",
  "sp-state-machine",

--- a/client/orchestrator-chain-interface/Cargo.toml
+++ b/client/orchestrator-chain-interface/Cargo.toml
@@ -13,6 +13,7 @@ async-trait = { workspace = true }
 futures = { workspace = true }
 jsonrpsee = { workspace = true }
 parity-scale-codec = { workspace = true }
+serde = { workspace = true }
 thiserror = { workspace = true }
 
 # Dancekit

--- a/client/orchestrator-chain-interface/src/lib.rs
+++ b/client/orchestrator-chain-interface/src/lib.rs
@@ -27,6 +27,7 @@
 use {
     core::pin::Pin, dp_core::ParaId, futures::Stream, polkadot_overseer::Handle,
     sc_client_api::StorageProof, sp_api::ApiError, sp_state_machine::StorageValue, std::sync::Arc,
+    parity_scale_codec::{Encode, Decode}
 };
 pub use {
     cumulus_primitives_core::relay_chain::Slot,
@@ -91,6 +92,21 @@ impl From<Box<dyn sp_state_machine::Error>> for OrchestratorChainError {
 // TODO: proper errors
 pub type OrchestratorChainResult<T> = Result<T, OrchestratorChainError>;
 
+pub type DataPreserverProfileId = u64;
+
+// Copy of Tanssi's pallet_data_preservers_runtime_api::Assignment
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Encode, Decode, serde::Serialize, serde::Deserialize)]
+pub enum DataPreserverAssignment<ParaId> {
+    /// Profile is not currently assigned.
+    NotAssigned,
+    /// Profile is activly assigned to this ParaId.
+    Active(ParaId),
+    /// Profile is assigned to this ParaId but is inactive for some reason.
+    /// It may be causes by conditions defined in the assignement configuration,
+    /// such as lacking payment.
+    Inactive(ParaId),
+}
+
 /// Trait that provides all necessary methods for interaction between collator and orchestrator chain.
 #[async_trait::async_trait]
 pub trait OrchestratorChainInterface: Send + Sync {
@@ -147,6 +163,12 @@ pub trait OrchestratorChainInterface: Send + Sync {
     async fn best_block_hash(&self) -> OrchestratorChainResult<PHash>;
 
     async fn finalized_block_hash(&self) -> OrchestratorChainResult<PHash>;
+
+    async fn get_active_assignment(
+        &self,
+        orchestrator_parent: PHash,
+        profile_id: DataPreserverProfileId,
+    ) -> OrchestratorChainResult<DataPreserverAssignment<ParaId>>;
 }
 
 #[async_trait::async_trait]
@@ -226,5 +248,15 @@ where
 
     async fn finalized_block_hash(&self) -> OrchestratorChainResult<PHash> {
         (**self).finalized_block_hash().await
+    }
+
+    async fn get_active_assignment(
+        &self,
+        orchestrator_parent: PHash,
+        profile_id: DataPreserverProfileId,
+    ) -> OrchestratorChainResult<DataPreserverAssignment<ParaId>> {
+        (**self)
+            .get_active_assignment(orchestrator_parent, profile_id)
+            .await
     }
 }

--- a/client/orchestrator-chain-interface/src/lib.rs
+++ b/client/orchestrator-chain-interface/src/lib.rs
@@ -164,7 +164,7 @@ pub trait OrchestratorChainInterface: Send + Sync {
 
     async fn finalized_block_hash(&self) -> OrchestratorChainResult<PHash>;
 
-    async fn get_active_assignment(
+    async fn data_preserver_active_assignment(
         &self,
         orchestrator_parent: PHash,
         profile_id: DataPreserverProfileId,
@@ -250,13 +250,13 @@ where
         (**self).finalized_block_hash().await
     }
 
-    async fn get_active_assignment(
+    async fn data_preserver_active_assignment(
         &self,
         orchestrator_parent: PHash,
         profile_id: DataPreserverProfileId,
     ) -> OrchestratorChainResult<DataPreserverAssignment<ParaId>> {
         (**self)
-            .get_active_assignment(orchestrator_parent, profile_id)
+            .data_preserver_active_assignment(orchestrator_parent, profile_id)
             .await
     }
 }

--- a/client/orchestrator-chain-interface/src/lib.rs
+++ b/client/orchestrator-chain-interface/src/lib.rs
@@ -25,9 +25,15 @@
 //! prove_read: generates a storage proof of a given set of keys at a given Orchestrator parent
 
 use {
-    core::pin::Pin, dp_core::ParaId, futures::Stream, polkadot_overseer::Handle,
-    sc_client_api::StorageProof, sp_api::ApiError, sp_state_machine::StorageValue, std::sync::Arc,
-    parity_scale_codec::{Encode, Decode}
+    core::pin::Pin,
+    dp_core::ParaId,
+    futures::Stream,
+    parity_scale_codec::{Decode, Encode},
+    polkadot_overseer::Handle,
+    sc_client_api::StorageProof,
+    sp_api::ApiError,
+    sp_state_machine::StorageValue,
+    std::sync::Arc,
 };
 pub use {
     cumulus_primitives_core::relay_chain::Slot,
@@ -95,7 +101,9 @@ pub type OrchestratorChainResult<T> = Result<T, OrchestratorChainError>;
 pub type DataPreserverProfileId = u64;
 
 // Copy of Tanssi's pallet_data_preservers_runtime_api::Assignment
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Encode, Decode, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Debug, Copy, Clone, PartialEq, Eq, Encode, Decode, serde::Serialize, serde::Deserialize,
+)]
 pub enum DataPreserverAssignment<ParaId> {
     /// Profile is not currently assigned.
     NotAssigned,

--- a/container-chain-primitives/authorities-noting-inherent/src/tests.rs
+++ b/container-chain-primitives/authorities-noting-inherent/src/tests.rs
@@ -27,7 +27,8 @@ use {
     },
     cumulus_relay_chain_interface::{PHash, PHeader, RelayChainInterface, RelayChainResult},
     dc_orchestrator_chain_interface::{
-        BlockNumber, ContainerChainGenesisData, OrchestratorChainInterface, OrchestratorChainResult,
+        BlockNumber, ContainerChainGenesisData, DataPreserverAssignment, DataPreserverProfileId,
+        OrchestratorChainInterface, OrchestratorChainResult,
     },
     dp_core::{well_known_keys, Header as OrchestratorHeader},
     futures::Stream,
@@ -161,6 +162,14 @@ impl OrchestratorChainInterface for DummyOrchestratorChainInterface {
     }
 
     async fn finalized_block_hash(&self) -> OrchestratorChainResult<PHash> {
+        unimplemented!("Not needed for test")
+    }
+
+    async fn get_active_assignment(
+        &self,
+        orchestrator_parent: PHash,
+        profile_id: DataPreserverProfileId,
+    ) -> OrchestratorChainResult<DataPreserverAssignment<ParaId>> {
         unimplemented!("Not needed for test")
     }
 }

--- a/container-chain-primitives/authorities-noting-inherent/src/tests.rs
+++ b/container-chain-primitives/authorities-noting-inherent/src/tests.rs
@@ -165,7 +165,7 @@ impl OrchestratorChainInterface for DummyOrchestratorChainInterface {
         unimplemented!("Not needed for test")
     }
 
-    async fn get_active_assignment(
+    async fn data_preserver_active_assignment(
         &self,
         orchestrator_parent: PHash,
         profile_id: DataPreserverProfileId,

--- a/container-chain-primitives/authorities-noting-inherent/src/tests.rs
+++ b/container-chain-primitives/authorities-noting-inherent/src/tests.rs
@@ -167,8 +167,8 @@ impl OrchestratorChainInterface for DummyOrchestratorChainInterface {
 
     async fn data_preserver_active_assignment(
         &self,
-        orchestrator_parent: PHash,
-        profile_id: DataPreserverProfileId,
+        _orchestrator_parent: PHash,
+        _profile_id: DataPreserverProfileId,
     ) -> OrchestratorChainResult<DataPreserverAssignment<ParaId>> {
         unimplemented!("Not needed for test")
     }


### PR DESCRIPTION
Allows to query the current data preserver assignment status.

Returns a simple enum describing the current status of the assignment (not assigned, assigned+active, assigned+inactive). In Tanssi it will be implemented by a runtime api that will look at the assignment and its witness to return the current status. Having this simple enum avoids depending on types configured in the runtime, and avoids client side changes when new payment methods are supported in the runtime.