### PR TITLE
Add check_assigned_para_id to OrchestratorChainInterface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1681,6 +1681,7 @@ dependencies = [
  "dp-core",
  "futures",
  "jsonrpsee",
+ "nimbus-primitives",
  "parity-scale-codec",
  "polkadot-overseer",
  "sc-client-api",

--- a/client/orchestrator-chain-interface/Cargo.toml
+++ b/client/orchestrator-chain-interface/Cargo.toml
@@ -31,3 +31,6 @@ polkadot-overseer = { workspace = true }
 
 # Cumulus
 cumulus-primitives-core = { workspace = true, features = [ "std" ] }
+
+# Nimbus
+nimbus-primitives = { workspace = true }

--- a/client/orchestrator-chain-interface/src/lib.rs
+++ b/client/orchestrator-chain-interface/src/lib.rs
@@ -39,6 +39,7 @@ pub use {
     cumulus_primitives_core::relay_chain::Slot,
     dp_container_chain_genesis_data::ContainerChainGenesisData,
     dp_core::{BlockNumber, Hash as PHash, Header as PHeader},
+    nimbus_primitives::NimbusId,
 };
 
 #[derive(thiserror::Error, Debug)]
@@ -177,6 +178,18 @@ pub trait OrchestratorChainInterface: Send + Sync {
         orchestrator_parent: PHash,
         profile_id: DataPreserverProfileId,
     ) -> OrchestratorChainResult<DataPreserverAssignment<ParaId>>;
+
+    async fn check_para_id_assignment(
+        &self,
+        orchestrator_parent: PHash,
+        authority: NimbusId,
+    ) -> OrchestratorChainResult<Option<ParaId>>;
+
+    async fn check_para_id_assignment_next_session(
+        &self,
+        orchestrator_parent: PHash,
+        authority: NimbusId,
+    ) -> OrchestratorChainResult<Option<ParaId>>;
 }
 
 #[async_trait::async_trait]
@@ -265,6 +278,26 @@ where
     ) -> OrchestratorChainResult<DataPreserverAssignment<ParaId>> {
         (**self)
             .data_preserver_active_assignment(orchestrator_parent, profile_id)
+            .await
+    }
+
+    async fn check_para_id_assignment(
+        &self,
+        orchestrator_parent: PHash,
+        authority: NimbusId,
+    ) -> OrchestratorChainResult<Option<ParaId>> {
+        (**self)
+            .check_para_id_assignment(orchestrator_parent, authority)
+            .await
+    }
+
+    async fn check_para_id_assignment_next_session(
+        &self,
+        orchestrator_parent: PHash,
+        authority: NimbusId,
+    ) -> OrchestratorChainResult<Option<ParaId>> {
+        (**self)
+            .check_para_id_assignment_next_session(orchestrator_parent, authority)
             .await
     }
 }

--- a/container-chain-primitives/authorities-noting-inherent/src/tests.rs
+++ b/container-chain-primitives/authorities-noting-inherent/src/tests.rs
@@ -172,6 +172,22 @@ impl OrchestratorChainInterface for DummyOrchestratorChainInterface {
     ) -> OrchestratorChainResult<DataPreserverAssignment<ParaId>> {
         unimplemented!("Not needed for test")
     }
+
+    async fn check_para_id_assignment(
+        &self,
+        _orchestrator_parent: PHash,
+        _authority: NimbusId,
+    ) -> OrchestratorChainResult<Option<ParaId>> {
+        unimplemented!("Not needed for test")
+    }
+
+    async fn check_para_id_assignment_next_session(
+        &self,
+        _orchestrator_parent: PHash,
+        _authority: NimbusId,
+    ) -> OrchestratorChainResult<Option<ParaId>> {
+        unimplemented!("Not needed for test")
+    }
 }
 
 #[async_trait]

--- a/container-chain-primitives/authorities-noting-inherent/src/tests.rs
+++ b/container-chain-primitives/authorities-noting-inherent/src/tests.rs
@@ -32,6 +32,7 @@ use {
     },
     dp_core::{well_known_keys, Header as OrchestratorHeader},
     futures::Stream,
+    nimbus_primitives::NimbusId,
     polkadot_overseer::Handle,
     sc_client_api::{HeaderBackend, StorageKey, StorageProvider},
     sp_inherents::{InherentData, InherentDataProvider},


### PR DESCRIPTION
This allows us to remove the `first_eligible_key_solochain` function from https://github.com/moondance-labs/tanssi/pull/664