### PR TITLE
Fixed `json` module + tests for updated ContainerChainGenesisData

### DIFF
--- a/primitives/container-chain-genesis-data/src/lib.rs
+++ b/primitives/container-chain-genesis-data/src/lib.rs
@@ -95,18 +95,6 @@ pub struct ContainerChainGenesisData {
     pub properties: Properties,
 }
 
-fn format_error_message(vec_len: usize, capacity: u32) -> String {
-    let mut error_message = String::new();
-
-    error_message.push_str("Failed to convert Vec<u8> (length: ");
-    error_message.push_str(&vec_len.to_string());
-    error_message.push_str(") to BoundedVec (capacity: ");
-    error_message.push_str(&capacity.to_string());
-    error_message.push_str(").");
-
-    error_message
-}
-
 fn serialize_bounded_vec_as_hex<S, const N: u32>(
     bv: &BoundedVec<u8, ConstU32<N>>,
     serializer: S,
@@ -125,7 +113,7 @@ where
 {
     let vec: Vec<u8> = bytes::deserialize(deserializer)?;
     BoundedVec::try_from(vec.clone())
-        .map_err(|_| serde::de::Error::custom(format_error_message(vec.len(), N)))
+        .map_err(|_| serde::de::Error::custom("Failed to convert Vec to BoundedVec"))
 }
 
 #[derive(

--- a/primitives/container-chain-genesis-data/src/lib.rs
+++ b/primitives/container-chain-genesis-data/src/lib.rs
@@ -95,6 +95,18 @@ pub struct ContainerChainGenesisData {
     pub properties: Properties,
 }
 
+fn format_error_message(vec_len: usize, capacity: u32) -> String {
+    let mut error_message = String::new();
+
+    error_message.push_str("Failed to convert Vec<u8> (length: ");
+    error_message.push_str(&vec_len.to_string());
+    error_message.push_str(") to BoundedVec (capacity: ");
+    error_message.push_str(&capacity.to_string());
+    error_message.push_str(").");
+
+    error_message
+}
+
 fn serialize_bounded_vec_as_hex<S, const N: u32>(
     bv: &BoundedVec<u8, ConstU32<N>>,
     serializer: S,
@@ -112,14 +124,8 @@ where
     D: Deserializer<'de>,
 {
     let vec: Vec<u8> = bytes::deserialize(deserializer)?;
-    BoundedVec::try_from(vec.clone()).map_err(|e| {
-        serde::de::Error::custom(format!(
-            "Failed to convert Vec<u8> (length: {}) to BoundedVec (capacity: {}): {:?}",
-            vec.len(),
-            N,
-            e
-        ))
-    })
+    BoundedVec::try_from(vec.clone())
+        .map_err(|_| serde::de::Error::custom(format_error_message(vec.len(), N)))
 }
 
 #[derive(


### PR DESCRIPTION
**What's done:**
- Fixed usage of the ContainerChainGenesisData struct for `json` lib (it was disabled and missed in the [initial PR](https://github.com/moondance-labs/dancekit/pull/37))
- Removed usage `std` macros, like `!format` from `primitives/container-chain-genesis-data/src/lib.rs`, because it is disabled for the runtimes in `tanssi`.

TODO:
- [ ] Once PR is approved and merged, cherry-pick of the squashed commit to branch `tanssi-polkadot-stable2412` and link the commit hash to the `tanssi` repo. 