### PR TITLE
Make DidSetOrchestratorAuthorityData public

### DIFF
--- a/container-chain-pallets/authorities-noting/src/lib.rs
+++ b/container-chain-pallets/authorities-noting/src/lib.rs
@@ -269,7 +269,7 @@ pub mod pallet {
 
     /// Was the containerAuthorData set?
     #[pallet::storage]
-    pub(super) type DidSetOrchestratorAuthorityData<T: Config> = StorageValue<_, bool, ValueQuery>;
+    pub type DidSetOrchestratorAuthorityData<T: Config> = StorageValue<_, bool, ValueQuery>;
 
     #[pallet::inherent]
     impl<T: Config> ProvideInherent for Pallet<T> {


### PR DESCRIPTION
# Description

Make `authorities_noting::DidSetOrchestratorAuthorityData` public to modify it from other crates if we need